### PR TITLE
feat(note, docs): 공통 응답 래퍼 클래스 전환 및 DTO 스키마 문서화

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/global/config/SecurityConfig.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/config/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
                                 "/v1/docs",
                                 "/docs/**",
                                 "/v1/api-docs/**",
-                                "/swagger-ui/**"
+                                "/swagger-ui/**",
+                                "/v1",
+                                "/v1/**"
                                 ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/MemoryMe/src/main/java/memme/memoryme/global/docs/response/NoteResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/docs/response/NoteResponse.java
@@ -1,0 +1,42 @@
+package memme.memoryme.global.docs.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import memme.memoryme.global.util.response.ResponseWrapper;
+import memme.memoryme.note.api.dto.note.NoteDto;
+
+import java.time.LocalDateTime;
+
+// Swagger에 표시할 반환 스키마
+@Schema(
+        name = "NoteResponse",
+        description = "메모 단건 응답",
+        example = """
+                {
+                  "success": true,
+                  "status": 200,
+                  "message": "메모 생성 성공",
+                  "timestamp": "2026-03-20T16:10:00",
+                  "data": {
+                    "uid": "550e8400-e29b-41d4-a716-446655440000",
+                    "title": "오늘 회의 정리",
+                    "post": {
+                      "content": "오늘은 회의 내용을 정리하고 다음 작업 일정을 정했다.",
+                      "images": [
+                        "https://cdn.example.com/images/note-1.png"
+                      ],
+                      "files": [
+                        "https://cdn.example.com/files/meeting-notes.pdf"
+                      ]
+                    },
+                    "created": "2026-03-20T14:30:00",
+                    "updated": "2026-03-20T15:10:00"
+                  }
+                }
+                """
+)
+public class NoteResponse extends ResponseWrapper<NoteDto> {
+
+    public NoteResponse(boolean success, int status, String message, LocalDateTime timestamp, NoteDto data) {
+        super(success, status, message, timestamp, data);
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/global/util/response/ResponseWrapper.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/util/response/ResponseWrapper.java
@@ -1,14 +1,33 @@
 package memme.memoryme.global.util.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
-public record ResponseWrapper<T>(
-        boolean success,
-        int status,
-        String message,
-        LocalDateTime timestamp,
-        T data
-) {
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "공통 응답 래퍼")
+public class ResponseWrapper<T> {
+
+    @Schema(description = "성공 여부", example = "true")
+    private boolean success;
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
+    private int status;
+
+    @Schema(description = "응답 메시지", example = "요청 성공")
+    private String message;
+
+    @Schema(description = "응답 시각", example = "2026-03-20T16:10:00")
+    private LocalDateTime timestamp;
+
+    @Schema(description = "실제 응답 데이터")
+    private T data;
+
     public static <T> ResponseWrapper<T> ok(int status, String message, T data) {
         return new ResponseWrapper<>(
                 true,

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/controller/NoteController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/controller/NoteController.java
@@ -6,6 +6,7 @@ import memme.memoryme.note.api.controller.api.NoteApi;
 import memme.memoryme.note.api.dto.note.NewNoteDto;
 import memme.memoryme.note.api.dto.note.NoteDto;
 import memme.memoryme.note.application.service.NoteService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +17,23 @@ public class NoteController implements NoteApi {
 
     @Override
     public ResponseEntity<ResponseWrapper<NoteDto>> toNoteDto(NewNoteDto newNote) {
-        return null;
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ResponseWrapper.ok(
+                    201,
+                    "생성 성공",
+                    noteService.createNote(newNote)
+                )
+        );
+    }
+
+    @Override
+    public ResponseEntity<ResponseWrapper<NoteDto>> updateNote(NoteDto noteDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                ResponseWrapper.ok(
+                        201,
+                        "수정 성공",
+                        noteService.updateNote(noteDto)
+                )
+        );
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/controller/api/NoteApi.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/controller/api/NoteApi.java
@@ -6,12 +6,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import memme.memoryme.global.docs.response.NoteResponse;
 import memme.memoryme.global.util.response.ResponseWrapper;
 import memme.memoryme.note.api.dto.note.NewNoteDto;
 import memme.memoryme.note.api.dto.note.NoteDto;
-import memme.memoryme.note.domain.Note;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,16 +26,44 @@ public interface NoteApi {
                             responseCode = "201",
                             description = "생성 성공",
                             content = @Content(
-                                    schema = @Schema(implementation = NewNoteDto.class)
+                                    schema = @Schema(implementation = NoteResponse.class)
                             )
                     ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(
+                            schema = @Schema(implementation = ResponseWrapper.class)
+                    )),
                     @ApiResponse(responseCode = "404", description = "데이터 없음", content = @Content),
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
             }
     )
     @PostMapping
-    // todo: Header로 UUID 받아오는 느낌으로 변경 해야 할 것 같음
+    // todo: Token에서 UUID 뽑아내어 사용
     ResponseEntity<ResponseWrapper<NoteDto>> toNoteDto(
             @Parameter(description = "새로운 메모")
-            @RequestBody NewNoteDto newNote);
+            @RequestBody NewNoteDto newNote
+    );
+
+    @Operation(
+            summary = "메모 수정",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "수정 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = NoteResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(
+                            schema = @Schema(implementation = ResponseWrapper.class)
+                    )),
+                    @ApiResponse(responseCode = "404", description = "데이터 없음", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+            }
+    )
+    @PatchMapping
+        // todo: Token에서 UUID 뽑아내어 사용
+    ResponseEntity<ResponseWrapper<NoteDto>> updateNote(
+            @Parameter(description = "수정 할 메모")
+            @RequestBody NoteDto noteDto
+    );
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/note/NewNoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/note/NewNoteDto.java
@@ -1,7 +1,9 @@
 package memme.memoryme.note.api.dto.note;
 
 public record NewNoteDto(
+        // 추후 삭제
         Long userId,
+
         String title
 ) {
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/note/NoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/note/NoteDto.java
@@ -1,16 +1,42 @@
 package memme.memoryme.note.api.dto.note;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import memme.memoryme.note.api.dto.post.PostDto;
 import memme.memoryme.note.domain.Note;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Schema(description = "메모 응답 DTO")
 public record NoteDto(
+
+        @Schema(
+                description = "메모 고유 식별자",
+                example = "550e8400-e29b-41d4-a716-446655440000"
+        )
         UUID uid,
+
+        @Schema(
+                description = "메모 제목",
+                example = "오늘 회의 정리"
+        )
         String title,
+
+        @Schema(
+                description = "메모 본문"
+        )
         PostDto post,
+
+        @Schema(
+                description = "메모 생성 시각",
+                example = "2026-03-20T14:30:00"
+        )
         LocalDateTime created,
+
+        @Schema(
+                description = "메모 수정 시각",
+                example = "2026-03-20T15:10:00"
+        )
         LocalDateTime updated
 ) {
     public static NoteDto from(Note note) {

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/post/PostDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/post/PostDto.java
@@ -1,12 +1,34 @@
 package memme.memoryme.note.api.dto.post;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import memme.memoryme.note.domain.Post;
 
 import java.util.List;
 
+@Schema(description = "메모 본문 DTO")
 public record PostDto(
+
+        @Schema(
+                description = "메모 본문 내용",
+                example = "오늘은 회의 내용을 정리하고 다음 작업 일정을 정했다."
+        )
         String content,
+
+        @ArraySchema(
+                schema = @Schema(
+                        description = "본문에 포함된 이미지 URL (추후 변경될 수 있음)",
+                        example = "https://cdn.example.com/images/note-1.png"
+                )
+        )
         List<String> images,
+
+        @ArraySchema(
+                schema = @Schema(
+                        description = "본문에 첨부된 파일 URL (추후 변경될 수 있음)",
+                        example = "https://cdn.example.com/files/meeting-notes.pdf"
+                )
+        )
         List<String> files
 ) {
     public static PostDto from(Post post) {

--- a/MemoryMe/src/main/java/memme/memoryme/note/application/service/impl/NoteServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/application/service/impl/NoteServiceImpl.java
@@ -9,6 +9,7 @@ import memme.memoryme.note.application.service.NoteService;
 import memme.memoryme.note.domain.Note;
 import memme.memoryme.note.domain.Post;
 import memme.memoryme.note.infra.repository.NoteRepository;
+import memme.memoryme.note.infra.repository.PostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class NoteServiceImpl implements NoteService {
     private final NoteRepository noteRepository;
+    private final PostRepository postRepository;
     private final CurrentUserProvider currentUserProvider;
 
     @Override
@@ -29,7 +31,8 @@ public class NoteServiceImpl implements NoteService {
                 Note.builder()
                         .uid(UUID.randomUUID())
                         // todo: userId의 타입 확인 후 변경
-                        .userId(Long.parseLong(currentUserProvider.getUserId()))
+//                        .userId(Long.parseLong(currentUserProvider.getUserId()))
+                        .userId(newNoteDto.userId())
                         .title(newNoteDto.title())
                         .build()
         );
@@ -44,18 +47,14 @@ public class NoteServiceImpl implements NoteService {
                 // todo: 예외 처리 핸들러 작성 필요
                 .orElseThrow(() -> new IllegalArgumentException("Note not found"));
 
-        if (noteDto.post() == null) {
-            note.setPost(null);
-        } else {
-            Post post = note.getPost();
-            if (post == null) {
-                post = new Post();
-                note.setPost(post);
-            }
-            updatePost(post, noteDto.post());
-        }
+        updateNotePost(note, noteDto.post());
 
         return toNoteDto(note);
+    }
+
+    @Transactional
+    public void deleteNote(UUID noteUid) {
+        noteRepository.deleteByUid(noteUid);
     }
 
     // Page || Slice 고민중
@@ -63,11 +62,33 @@ public class NoteServiceImpl implements NoteService {
         return List.of();
     }
 
+    /*----private 메소드----*/
+
+    private void updateNotePost(Note note, PostDto postDto) {
+        if (postDto == null) {
+            note.setPost(null);
+            return;
+        }
+
+        Post post = getOrCreatePost(note);
+        updatePost(post, postDto);
+    }
+
+    private Post getOrCreatePost(Note note) {
+        if (note.getPost() != null) {
+            return note.getPost();
+        }
+
+        Post newPost = postRepository.save(new Post());
+        note.setPost(newPost);
+        return newPost;
+    }
+
     private NoteDto toNoteDto(Note note) {
         return NoteDto.from(note);
     }
 
-    private static void updatePost(Post post, PostDto postDto) {
+    private void updatePost(Post post, PostDto postDto) {
         post.setContent(postDto.content());
         post.setImages(postDto.images());
         post.setFiles(postDto.files());

--- a/MemoryMe/src/main/java/memme/memoryme/note/domain/Post.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/domain/Post.java
@@ -6,6 +6,7 @@ import lombok.*;
 import java.util.List;
 
 @Entity
+@Table(name = "post")
 @Builder
 @Getter
 @Setter

--- a/MemoryMe/src/main/java/memme/memoryme/note/infra/repository/NoteRepository.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/infra/repository/NoteRepository.java
@@ -10,4 +10,5 @@ import java.util.UUID;
 @Repository
 public interface NoteRepository extends JpaRepository<Note, Long> {
     Optional<Note> findByUid(UUID uid);
+    void deleteByUid(UUID uid);
 }

--- a/MemoryMe/src/main/resources/application-prod.yaml
+++ b/MemoryMe/src/main/resources/application-prod.yaml
@@ -36,11 +36,17 @@ server:
 
 springdoc:
   swagger-ui:
-    path: /v1/docs
-    operations-sorter: method
+    operations-sorter: alpha
+    tags-sorter: alpha
+    doc-expansion: none
+    deep-linking: true
+    display-request-duration: true
+    filter: true
+    try-it-out-enabled: true
+    persist-authorization: true
+
   api-docs:
     path: /v1/api-docs
-  show-actuator: true
 
 # spring:
 #   web:


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- NoteController 작성, API 작성
- ResponseWrapper를 record에서 class로 변경
- Swagger 문서화를 위해 NoteDto, PostDto에 Schema 설명 및 예시 추가
- NoteResponse 등 문서용 응답 스키마 구성
- 제네릭 응답 구조가 Swagger에 더 잘 노출되도록 정리


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
- global/docs/response와 global/util/response 확인 후 api 인터페이스에 반영해주세요
