### PR TITLE
feat(upload): 첨부파일 업로드 S3 전환

### DIFF
--- a/MemoryMe/build.gradle
+++ b/MemoryMe/build.gradle
@@ -3,6 +3,9 @@ plugins {
     id 'org.springframework.boot' version '4.0.2'
     id 'io.spring.dependency-management' version '1.1.7'
 }
+ext {
+    springAiVersion = "2.0.0-M5"
+}
 
 group = 'memme'
 version = '0.0.1-SNAPSHOT'
@@ -47,6 +50,13 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation platform("software.amazon.awssdk:bom:2.44.2")
+    implementation "software.amazon.awssdk:s3"
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
+    }
 }
 
 tasks.named('test') {

--- a/MemoryMe/src/main/java/memme/memoryme/board/api/controller/api/BoardApi.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/controller/api/BoardApi.java
@@ -40,7 +40,7 @@ public interface BoardApi {
     @PatchMapping("/{boardUid}/bookmark")
     ResponseEntity<ResponseWrapper<BoardDto>> updateBookmark(
             @PathVariable UUID boardUid,
-            @RequestBody BoardBookmarkRequest request
+            @RequestBody(required = false) BoardBookmarkRequest request
     );
 
     @Operation(summary = "노트 생성")

--- a/MemoryMe/src/main/java/memme/memoryme/board/api/dto/BoardBookmarkRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/dto/BoardBookmarkRequest.java
@@ -5,9 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "보드 북마크 변경 요청 DTO")
 public record BoardBookmarkRequest(
         @Schema(description = "북마크 여부", example = "true")
-        Boolean bookmarked
+        Boolean bookmarked,
+        @Schema(description = "기존 프론트 호환용 북마크 여부", example = "true")
+        Boolean bookMark
 ) {
     public boolean valueOrFalse() {
-        return Boolean.TRUE.equals(bookmarked);
+        return Boolean.TRUE.equals(bookmarked) || Boolean.TRUE.equals(bookMark);
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -13,6 +13,7 @@ import memme.memoryme.note.domain.AttachmentType;
 import memme.memoryme.note.domain.Note;
 import memme.memoryme.note.domain.NoteAttachment;
 import memme.memoryme.note.infra.repository.NoteRepository;
+import memme.memoryme.upload.application.service.S3ObjectUrlBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,12 +26,16 @@ public class BoardServiceImpl implements BoardService {
     private final NoteRepository noteRepository;
     private final CurrentUserProvider currentUserProvider;
     private final UserReader userReader;
+    private final S3ObjectUrlBuilder objectUrlBuilder;
 
     @Override
     @Transactional
     public BoardDto createBoard(CreateBoardRequest request) {
         UUID userUid = currentUserProvider.getUid();
         validateUserExists(userUid);
+        if (request == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_BOARD_REQUEST);
+        }
         validateBoardTitle(request.title());
 
         Board board = Board.builder()
@@ -42,19 +47,21 @@ public class BoardServiceImpl implements BoardService {
                 .bookmarked(false)
                 .build();
 
-        return BoardDto.from(boardRepository.save(board));
+        return BoardDto.from(boardRepository.saveAndFlush(board));
     }
 
     @Override
     @Transactional(readOnly = true)
     public BoardDto getBoard(UUID boardUid) {
-        Board board = getCurrentUserBoard(boardUid);
-        return BoardDto.from(board);
+        return BoardDto.from(getCurrentUserBoard(boardUid));
     }
 
     @Override
     @Transactional
     public BoardDto updateBoard(UUID boardUid, UpdateBoardRequest request) {
+        if (request == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_BOARD_REQUEST);
+        }
         Board board = getCurrentUserBoard(boardUid);
         validateBoardTitle(request.title());
 
@@ -63,6 +70,7 @@ public class BoardServiceImpl implements BoardService {
                 blankToNull(request.description()),
                 normalizeTags(request.tags())
         );
+        boardRepository.flush();
         return BoardDto.from(board);
     }
 
@@ -79,13 +87,17 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public BoardDto updateBookmark(UUID boardUid, BoardBookmarkRequest request) {
         Board board = getCurrentUserBoard(boardUid);
-        board.changeBookmarked(request.valueOrFalse());
+        board.changeBookmarked(request != null && request.valueOrFalse());
+        boardRepository.flush();
         return BoardDto.from(board);
     }
 
     @Override
     @Transactional
     public NoteDto createNote(UUID boardUid, CreateNoteRequest request) {
+        if (request == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
+        }
         Board board = getCurrentUserBoard(boardUid);
         validateNoteTitle(request.title());
 
@@ -98,17 +110,20 @@ public class BoardServiceImpl implements BoardService {
                 .ogDescription(request.ogData() != null ? blankToNull(request.ogData().description()) : null)
                 .ogImageUrl(request.ogData() != null ? blankToNull(request.ogData().imageUrl()) : null)
                 .ogSiteName(request.ogData() != null ? blankToNull(request.ogData().siteName()) : null)
-                .sortOrder(board.nextSortOrder())
                 .build();
 
-        note.replaceAttachments(toAttachments(request.imageUris(), request.videoUris(), request.files()));
+        note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
         board.addNote(note);
+        boardRepository.flush();
         return NoteDto.from(note);
     }
 
     @Override
     @Transactional
     public NoteDto updateNote(UUID boardUid, UUID noteUid, UpdateNoteRequest request) {
+        if (request == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
+        }
         Board board = getCurrentUserBoard(boardUid);
         Note note = findNote(board, noteUid);
         validateNoteTitle(request.title());
@@ -122,8 +137,9 @@ public class BoardServiceImpl implements BoardService {
                 request.ogData() != null ? blankToNull(request.ogData().imageUrl()) : null,
                 request.ogData() != null ? blankToNull(request.ogData().siteName()) : null
         );
-        note.replaceAttachments(toAttachments(request.imageUris(), request.videoUris(), request.files()));
+        note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
         board.touch();
+        boardRepository.flush();
         return NoteDto.from(note);
     }
 
@@ -134,24 +150,27 @@ public class BoardServiceImpl implements BoardService {
         Note note = findNote(board, noteUid);
         board.removeNote(note);
         noteRepository.delete(note);
+        boardRepository.flush();
     }
 
     @Override
     @Transactional
     public MoveNoteResponse moveNote(UUID sourceBoardUid, UUID noteUid, MoveNoteRequest request) {
-        if (request.targetBoardUid() == null) {
+        UUID targetBoardUid = request == null ? null : request.resolvedTargetBoardUid();
+        if (targetBoardUid == null) {
             throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
         }
-        if (sourceBoardUid.equals(request.targetBoardUid())) {
+        if (sourceBoardUid.equals(targetBoardUid)) {
             throw new BusinessException(BoardErrorCode.SAME_BOARD_MOVE_NOT_ALLOWED);
         }
 
         Board sourceBoard = getCurrentUserBoard(sourceBoardUid);
-        Board targetBoard = getCurrentUserBoard(request.targetBoardUid());
+        Board targetBoard = getCurrentUserBoard(targetBoardUid);
         Note note = findNote(sourceBoard, noteUid);
 
         sourceBoard.removeNote(note);
         targetBoard.addNote(note);
+        boardRepository.flush();
 
         return new MoveNoteResponse(BoardDto.from(sourceBoard), BoardDto.from(targetBoard));
     }
@@ -209,42 +228,108 @@ public class BoardServiceImpl implements BoardService {
         return normalized;
     }
 
-    private List<NoteAttachment> toAttachments(List<String> imageUris, List<String> videoUris, List<FileAttachmentDto> files) {
+    private List<NoteAttachment> toAttachments(
+            UUID userUid,
+            List<String> imageUris,
+            List<String> imageKeys,
+            List<String> videoUris,
+            List<String> videoKeys,
+            List<FileAttachmentDto> files
+    ) {
         List<NoteAttachment> attachments = new ArrayList<>();
 
-        if (imageUris != null) {
-            if (imageUris.size() > 10) {
-                throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
-            }
-            imageUris.stream()
-                    .filter(url -> url != null && !url.isBlank())
-                    .map(url -> NoteAttachment.builder()
-                            .uid(UUID.randomUUID())
-                            .type(AttachmentType.IMAGE)
-                            .url(url.trim())
-                            .build())
-                    .forEach(attachments::add);
-        }
-
-        if (videoUris != null) {
-            videoUris.stream()
-                    .filter(url -> url != null && !url.isBlank())
-                    .map(url -> NoteAttachment.builder()
-                            .uid(UUID.randomUUID())
-                            .type(AttachmentType.VIDEO)
-                            .url(url.trim())
-                            .build())
-                    .forEach(attachments::add);
-        }
+        addUrlAttachments(attachments, userUid, AttachmentType.IMAGE, imageUris, null);
+        addKeyAttachments(attachments, userUid, AttachmentType.IMAGE, imageKeys);
+        addUrlAttachments(attachments, userUid, AttachmentType.VIDEO, videoUris, null);
+        addKeyAttachments(attachments, userUid, AttachmentType.VIDEO, videoKeys);
 
         if (files != null) {
             files.stream()
-                    .filter(file -> file != null && file.url() != null && !file.url().isBlank())
-                    .map(file -> file.toEntity(AttachmentType.FILE))
+                    .filter(file -> file != null && ((file.url() != null && !file.url().isBlank()) || (file.key() != null && !file.key().isBlank())))
+                    .map(file -> normalizeFileAttachment(file, userUid))
                     .forEach(attachments::add);
         }
 
+        long imageCount = attachments.stream().filter(attachment -> attachment.getType() == AttachmentType.IMAGE).count();
+        if (imageCount > 10) {
+            throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
+        }
+
         return attachments;
+    }
+
+    private void addUrlAttachments(List<NoteAttachment> attachments, UUID userUid, AttachmentType type, List<String> urls, String originalName) {
+        if (urls == null) {
+            return;
+        }
+        urls.stream()
+                .filter(url -> url != null && !url.isBlank())
+                .map(url -> NoteAttachment.builder()
+                        .uid(UUID.randomUUID())
+                        .userUid(userUid)
+                        .type(type)
+                        .originalName(originalName)
+                        .url(url.trim())
+                        .s3Key(extractKeyFromObjectUrl(url.trim()))
+                        .build())
+                .forEach(attachments::add);
+    }
+
+    private void addKeyAttachments(List<NoteAttachment> attachments, UUID userUid, AttachmentType type, List<String> keys) {
+        if (keys == null) {
+            return;
+        }
+        keys.stream()
+                .filter(key -> key != null && !key.isBlank())
+                .map(key -> key.trim())
+                .map(key -> NoteAttachment.builder()
+                        .uid(UUID.randomUUID())
+                        .userUid(userUid)
+                        .type(type)
+                        .url(objectUrlBuilder.build(key))
+                        .s3Key(key)
+                        .build())
+                .forEach(attachments::add);
+    }
+
+    private NoteAttachment normalizeFileAttachment(FileAttachmentDto file, UUID userUid) {
+        String key = blankToNull(file.key());
+        String url = blankToNull(file.url());
+        if (url == null && key != null) {
+            url = objectUrlBuilder.build(key);
+        }
+        if (key == null && url != null) {
+            key = extractKeyFromObjectUrl(url);
+        }
+        return NoteAttachment.builder()
+                .uid(file.uid() != null ? file.uid() : UUID.randomUUID())
+                .userUid(userUid)
+                .type(AttachmentType.FILE)
+                .originalName(blankToNull(file.name()))
+                .url(url)
+                .s3Key(key)
+                .mimeType(blankToNull(file.mimeType()))
+                .sizeBytes(file.size())
+                .thumbnailUrl(blankToNull(file.thumbnailUrl()))
+                .durationSeconds(file.duration())
+                .build();
+    }
+
+    private String extractKeyFromObjectUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String marker = "key=";
+        int index = url.indexOf(marker);
+        if (index < 0) {
+            return null;
+        }
+        String encodedKey = url.substring(index + marker.length());
+        int ampIndex = encodedKey.indexOf('&');
+        if (ampIndex >= 0) {
+            encodedKey = encodedKey.substring(0, ampIndex);
+        }
+        return java.net.URLDecoder.decode(encodedKey, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     private String blankToNull(String value) {

--- a/MemoryMe/src/main/java/memme/memoryme/global/config/S3Config.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/config/S3Config.java
@@ -1,0 +1,46 @@
+package memme.memoryme.global.config;
+
+import lombok.RequiredArgsConstructor;
+import memme.memoryme.upload.config.S3StorageProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+    private final S3StorageProperties properties;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(region())
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(region())
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    private Region region() {
+        return Region.of(properties.getS3().getRegion());
+    }
+
+    private StaticCredentialsProvider credentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                        properties.getCredentials().getAccessKey(),
+                        properties.getCredentials().getSecretKey()
+                )
+        );
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/api/MemoApi.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/api/MemoApi.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @Tag(name = "Memo API", description = "빠른 메모 API")
-@RequestMapping("/v1/memos")
+@RequestMapping({"/v1/memos", "/v1/memo"})
 public interface MemoApi {
     @Operation(summary = "메모 생성")
     @PostMapping
@@ -33,7 +33,7 @@ public interface MemoApi {
     ResponseEntity<ResponseWrapper<MemoDto>> updateBookmark(
             @Parameter(description = "메모 UID")
             @PathVariable UUID memoUid,
-            @RequestBody BookmarkRequest request
+            @RequestBody(required = false) BookmarkRequest request
     );
 
     @Operation(summary = "메모를 새 보드로 변환")
@@ -48,6 +48,6 @@ public interface MemoApi {
     ResponseEntity<ResponseWrapper<BoardDto>> convertToExistingBoard(
             @PathVariable UUID memoUid,
             @PathVariable UUID boardUid,
-            @RequestBody ConvertMemoToExistingBoardRequest request
+            @RequestBody(required = false) ConvertMemoToExistingBoardRequest request
     );
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/api/dto/memo/BookmarkRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/api/dto/memo/BookmarkRequest.java
@@ -5,9 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "북마크 변경 요청 DTO")
 public record BookmarkRequest(
         @Schema(description = "북마크 여부", example = "true")
-        Boolean bookmarked
+        Boolean bookmarked,
+        @Schema(description = "기존 프론트 호환용 북마크 여부", example = "true")
+        Boolean bookMark
 ) {
     public boolean valueOrFalse() {
-        return Boolean.TRUE.equals(bookmarked);
+        return Boolean.TRUE.equals(bookmarked) || Boolean.TRUE.equals(bookMark);
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/api/dto/memo/NewMemoDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/api/dto/memo/NewMemoDto.java
@@ -5,6 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "메모 생성 요청 DTO")
 public record NewMemoDto(
         @Schema(description = "빠르게 남기는 메모 내용", example = "코딩 공부하기")
-        String text
+        String text,
+        @Schema(description = "기존 프론트 호환용 메모 내용", example = "코딩 공부하기")
+        String title,
+        @Schema(description = "기존 프론트 호환용 메모 내용", example = "코딩 공부하기")
+        String content
 ) {
+    public String resolvedText() {
+        if (text != null && !text.isBlank()) {
+            return text;
+        }
+        if (title != null && !title.isBlank()) {
+            return title;
+        }
+        return content;
+    }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
@@ -36,26 +36,26 @@ public class MemoServiceImpl implements MemoService {
     public MemoDto createMemo(NewMemoDto request) {
         UUID userUid = currentUserProvider.getUid();
         validateUserExists(userUid);
-        validateText(request.text());
+        String text = request == null ? null : request.resolvedText();
+        validateText(text);
 
         Memo memo = Memo.builder()
                 .uid(UUID.randomUUID())
                 .userUid(userUid)
-                .text(request.text().trim())
+                .text(text.trim())
                 .bookmarked(false)
                 .build();
 
-        return MemoDto.from(memoRepository.save(memo));
+        return MemoDto.from(memoRepository.saveAndFlush(memo));
     }
 
     @Override
     @Transactional
     public void deleteMemo(UUID memoUid) {
         UUID userUid = currentUserProvider.getUid();
-        if (!memoRepository.existsByUidAndUserUid(memoUid, userUid)) {
-            throw new BusinessException(MemoErrorCode.MEMO_NOT_FOUND);
-        }
-        memoRepository.deleteByUidAndUserUid(memoUid, userUid);
+        Memo memo = memoRepository.findByUidAndUserUid(memoUid, userUid)
+                .orElseThrow(() -> new BusinessException(MemoErrorCode.MEMO_NOT_FOUND));
+        memoRepository.delete(memo);
     }
 
     @Override
@@ -65,13 +65,17 @@ public class MemoServiceImpl implements MemoService {
         Memo memo = memoRepository.findByUidAndUserUid(memoUid, userUid)
                 .orElseThrow(() -> new BusinessException(MemoErrorCode.MEMO_NOT_FOUND));
 
-        memo.changeBookmarked(request.valueOrFalse());
+        memo.changeBookmarked(request != null && request.valueOrFalse());
         return MemoDto.from(memo);
     }
 
     @Override
     @Transactional
     public BoardDto convertToNewBoard(UUID memoUid, ConvertMemoToNewBoardRequest request) {
+        if (request == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_BOARD_REQUEST);
+        }
+
         UUID userUid = currentUserProvider.getUid();
         validateUserExists(userUid);
         Memo memo = getCurrentUserMemo(memoUid, userUid);
@@ -87,8 +91,9 @@ public class MemoServiceImpl implements MemoService {
                 .build();
 
         board.addNote(createNoteFromMemo(memo, request.noteTitle(), request.content()));
-        Board savedBoard = boardRepository.save(board);
+        Board savedBoard = boardRepository.saveAndFlush(board);
         memoRepository.delete(memo);
+        memoRepository.flush();
         return BoardDto.from(savedBoard);
     }
 
@@ -100,8 +105,12 @@ public class MemoServiceImpl implements MemoService {
         Board board = boardRepository.findByUidAndUserUid(boardUid, userUid)
                 .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
 
-        board.addNote(createNoteFromMemo(memo, request.noteTitle(), request.content()));
+        String noteTitle = request == null ? null : request.noteTitle();
+        String content = request == null ? null : request.content();
+        board.addNote(createNoteFromMemo(memo, noteTitle, content));
+        boardRepository.flush();
         memoRepository.delete(memo);
+        memoRepository.flush();
         return BoardDto.from(board);
     }
 
@@ -132,10 +141,7 @@ public class MemoServiceImpl implements MemoService {
     }
 
     private void validateText(String text) {
-        if (text == null || text.isBlank()) {
-            throw new BusinessException(MemoErrorCode.INVALID_MEMO_REQUEST);
-        }
-        if (text.length() > 2000) {
+        if (text == null || text.isBlank() || text.length() > 2000) {
             throw new BusinessException(MemoErrorCode.INVALID_MEMO_REQUEST);
         }
     }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/domain/Memo.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/domain/Memo.java
@@ -7,9 +7,9 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "quick_memo", indexes = {
+@Table(name = "memo", indexes = {
         @Index(name = "idx_memo_user_uid", columnList = "user_uid"),
-        @Index(name = "idx_memo_user_created_at", columnList = "user_uid, created_at")
+        @Index(name = "idx_memo_user_created", columnList = "user_uid, created")
 })
 @Getter
 @Builder
@@ -26,26 +26,43 @@ public class Memo {
     @Column(name = "user_uid", nullable = false, updatable = false)
     private UUID userUid;
 
-    @Column(nullable = false, length = 2000)
+    @Column(name = "title", nullable = false, length = 2000)
     private String text;
 
     @Column(nullable = false)
     private boolean bookmarked;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "updated", nullable = false)
+    private LocalDateTime updatedAt;
 
     public void changeBookmarked(boolean bookmarked) {
         this.bookmarked = bookmarked;
+        touch();
+    }
+
+    public void touch() {
+        this.updatedAt = LocalDateTime.now();
     }
 
     @PrePersist
     void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
         if (uid == null) {
             uid = UUID.randomUUID();
         }
         if (createdAt == null) {
-            createdAt = LocalDateTime.now();
+            createdAt = now;
         }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/infra/repository/MemoRepository.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/infra/repository/MemoRepository.java
@@ -10,8 +10,10 @@ import java.util.UUID;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
+    Optional<Memo> findByUid(UUID uid);
     Optional<Memo> findByUidAndUserUid(UUID uid, UUID userUid);
     boolean existsByUidAndUserUid(UUID uid, UUID userUid);
+    void deleteByUid(UUID uid);
     void deleteByUidAndUserUid(UUID uid, UUID userUid);
     List<Memo> findAllByUserUid(UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/CreateNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/CreateNoteRequest.java
@@ -12,8 +12,12 @@ public record CreateNoteRequest(
         String content,
         @Schema(description = "첨부 이미지 URL 목록")
         List<String> imageUris,
+        @Schema(description = "첨부 이미지 S3 key 목록")
+        List<String> imageKeys,
         @Schema(description = "첨부 영상 URL 목록")
         List<String> videoUris,
+        @Schema(description = "첨부 영상 S3 key 목록")
+        List<String> videoKeys,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
         @Schema(description = "링크 URL")

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
@@ -12,8 +12,10 @@ public record FileAttachmentDto(
         UUID uid,
         @Schema(description = "원본 파일명", example = "기획서.pdf")
         String name,
-        @Schema(description = "파일 URL", example = "https://cdn.example.com/uploads/plan.pdf")
+        @Schema(description = "파일 접근 URL", example = "/v1/upload/object?key=memme/users/.../file.pdf")
         String url,
+        @Schema(description = "S3 객체 key")
+        String key,
         @Schema(description = "MIME 타입", example = "application/pdf")
         String mimeType,
         @Schema(description = "파일 크기(bytes)", example = "204800")
@@ -28,6 +30,7 @@ public record FileAttachmentDto(
                 attachment.getUid(),
                 attachment.getOriginalName(),
                 attachment.getUrl(),
+                attachment.getS3Key(),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),
                 attachment.getThumbnailUrl(),
@@ -36,11 +39,17 @@ public record FileAttachmentDto(
     }
 
     public NoteAttachment toEntity(AttachmentType type) {
+        return toEntity(type, null);
+    }
+
+    public NoteAttachment toEntity(AttachmentType type, UUID userUid) {
         return NoteAttachment.builder()
                 .uid(uid != null ? uid : UUID.randomUUID())
+                .userUid(userUid)
                 .type(type)
                 .originalName(name)
                 .url(url)
+                .s3Key(key)
                 .mimeType(mimeType)
                 .sizeBytes(size)
                 .thumbnailUrl(thumbnailUrl)

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MoveNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MoveNoteRequest.java
@@ -7,6 +7,24 @@ import java.util.UUID;
 @Schema(description = "노트 이동 요청 DTO")
 public record MoveNoteRequest(
         @Schema(description = "대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
-        UUID targetBoardUid
+        UUID targetBoardUid,
+        @Schema(description = "기존 프론트 호환용 대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID targetBoardId,
+        @Schema(description = "기존 프론트 호환용 대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID boardUid,
+        @Schema(description = "기존 프론트 호환용 대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID boardId
 ) {
+    public UUID resolvedTargetBoardUid() {
+        if (targetBoardUid != null) {
+            return targetBoardUid;
+        }
+        if (targetBoardId != null) {
+            return targetBoardId;
+        }
+        if (boardUid != null) {
+            return boardUid;
+        }
+        return boardId;
+    }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/UpdateNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/UpdateNoteRequest.java
@@ -12,8 +12,12 @@ public record UpdateNoteRequest(
         String content,
         @Schema(description = "첨부 이미지 URL 목록")
         List<String> imageUris,
+        @Schema(description = "첨부 이미지 S3 key 목록")
+        List<String> imageKeys,
         @Schema(description = "첨부 영상 URL 목록")
         List<String> videoUris,
+        @Schema(description = "첨부 영상 S3 key 목록")
+        List<String> videoKeys,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
         @Schema(description = "링크 URL")

--- a/MemoryMe/src/main/java/memme/memoryme/note/domain/AttachmentStatus.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/domain/AttachmentStatus.java
@@ -1,0 +1,6 @@
+package memme.memoryme.note.domain;
+
+public enum AttachmentStatus {
+    ATTACHED,
+    DELETED
+}

--- a/MemoryMe/src/main/java/memme/memoryme/note/domain/NoteAttachment.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/domain/NoteAttachment.java
@@ -2,13 +2,16 @@ package memme.memoryme.note.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
 @Table(name = "note_attachment", indexes = {
-        @Index(name = "idx_attachment_note_id", columnList = "note_id")
+        @Index(name = "idx_attachment_note_id", columnList = "note_id"),
+        @Index(name = "idx_attachment_user_uid", columnList = "user_uid")
 })
 @Getter
 @Builder
@@ -26,15 +29,28 @@ public class NoteAttachment {
     @JoinColumn(name = "note_id")
     private Note note;
 
+    @Column(name = "user_uid")
+    private UUID userUid;
+
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(nullable = false, length = 20, columnDefinition = "varchar(20)")
     private AttachmentType type;
 
     @Column(name = "original_name")
     private String originalName;
 
+    @Column(name = "stored_name")
+    private String storedName;
+
     @Column(nullable = false, length = 2048)
     private String url;
+
+    @Column(name = "bucket")
+    private String bucket;
+
+    @Column(name = "s3_key", length = 512)
+    private String s3Key;
 
     @Column(name = "mime_type")
     private String mimeType;
@@ -48,11 +64,21 @@ public class NoteAttachment {
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
 
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(nullable = false, length = 20, columnDefinition = "varchar(20)")
+    @Builder.Default
+    private AttachmentStatus status = AttachmentStatus.ATTACHED;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     public void assignNote(Note note) {
         this.note = note;
+    }
+
+    public void markDeleted() {
+        this.status = AttachmentStatus.DELETED;
     }
 
     @PrePersist
@@ -62,6 +88,9 @@ public class NoteAttachment {
         }
         if (createdAt == null) {
             createdAt = LocalDateTime.now();
+        }
+        if (status == null) {
+            status = AttachmentStatus.ATTACHED;
         }
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/upload/api/controller/UploadController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/api/controller/UploadController.java
@@ -8,11 +8,13 @@ import memme.memoryme.upload.api.dto.FileUploadResponse;
 import memme.memoryme.upload.api.dto.ImageUploadResponse;
 import memme.memoryme.upload.api.dto.VideoUploadResponse;
 import memme.memoryme.upload.application.service.UploadService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
 import java.util.List;
 
 @Tag(name = "Upload API", description = "이미지·영상·파일 업로드 API")
@@ -38,5 +40,13 @@ public class UploadController {
     @PostMapping(value = "/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ResponseWrapper<FileUploadResponse>> uploadFile(@RequestPart("file") MultipartFile file) {
         return ResponseEntity.ok(ResponseWrapper.ok(200, "파일 업로드 성공", uploadService.uploadFile(file)));
+    }
+
+    @Operation(summary = "S3 객체 접근 URL 리다이렉트")
+    @GetMapping("/object")
+    public ResponseEntity<Void> redirectObject(@RequestParam("key") String key) {
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, URI.create(uploadService.createReadUrl(key)).toString())
+                .build();
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/FileUploadResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/FileUploadResponse.java
@@ -10,8 +10,10 @@ public record FileUploadResponse(
         UUID uid,
         @Schema(description = "원본 파일명")
         String name,
-        @Schema(description = "파일 URL")
+        @Schema(description = "파일 접근 URL")
         String url,
+        @Schema(description = "S3 객체 key")
+        String key,
         @Schema(description = "MIME 타입")
         String mimeType,
         @Schema(description = "파일 크기(bytes)")

--- a/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/ImageUploadResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/ImageUploadResponse.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 @Schema(description = "이미지 업로드 응답 DTO")
 public record ImageUploadResponse(
-        @Schema(description = "업로드된 이미지 URL 목록")
-        List<String> urls
+        @Schema(description = "업로드된 이미지 접근 URL 목록")
+        List<String> urls,
+        @Schema(description = "S3 객체 key 목록")
+        List<String> keys
 ) {
 }

--- a/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/VideoUploadResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/api/dto/VideoUploadResponse.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "영상 업로드 응답 DTO")
 public record VideoUploadResponse(
-        @Schema(description = "영상 URL")
+        @Schema(description = "영상 접근 URL")
         String url,
+        @Schema(description = "S3 객체 key")
+        String key,
         @Schema(description = "썸네일 URL")
         String thumbnailUrl,
         @Schema(description = "영상 길이(초)")

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/LocalUploadService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/LocalUploadService.java
@@ -6,6 +6,7 @@ import memme.memoryme.global.exception.CommonErrorCode;
 import memme.memoryme.upload.api.dto.FileUploadResponse;
 import memme.memoryme.upload.api.dto.ImageUploadResponse;
 import memme.memoryme.upload.api.dto.VideoUploadResponse;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@Profile("local-upload")
 @RequiredArgsConstructor
 public class LocalUploadService implements UploadService {
     private static final Path UPLOAD_ROOT = Path.of("uploads");
@@ -28,14 +30,15 @@ public class LocalUploadService implements UploadService {
         return new ImageUploadResponse(
                 files.stream()
                         .map(file -> store(file, "images"))
-                        .toList()
+                        .toList(),
+                List.of()
         );
     }
 
     @Override
     public VideoUploadResponse uploadVideo(MultipartFile file) {
         StoredFile storedFile = storeFile(file, "videos");
-        return new VideoUploadResponse(storedFile.url(), null, null, storedFile.size());
+        return new VideoUploadResponse(storedFile.url(), null, null, null, storedFile.size());
     }
 
     @Override
@@ -45,6 +48,7 @@ public class LocalUploadService implements UploadService {
                 storedFile.uid(),
                 storedFile.originalName(),
                 storedFile.url(),
+                null,
                 storedFile.mimeType(),
                 storedFile.size()
         );
@@ -79,6 +83,14 @@ public class LocalUploadService implements UploadService {
         } catch (IOException e) {
             throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public String createReadUrl(String key) {
+        if (key == null || key.isBlank()) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+        return key;
     }
 
     private String extension(String originalName) {

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3ObjectUrlBuilder.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3ObjectUrlBuilder.java
@@ -1,0 +1,13 @@
+package memme.memoryme.upload.application.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class S3ObjectUrlBuilder {
+    public String build(String key) {
+        return "/v1/upload/object?key=" + UriUtils.encodeQueryParam(key, StandardCharsets.UTF_8);
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3UploadService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3UploadService.java
@@ -1,0 +1,184 @@
+package memme.memoryme.upload.application.service;
+
+import lombok.RequiredArgsConstructor;
+import memme.memoryme.global.exception.BusinessException;
+import memme.memoryme.global.exception.CommonErrorCode;
+import memme.memoryme.global.util.jwt.CurrentUserProvider;
+import memme.memoryme.upload.api.dto.FileUploadResponse;
+import memme.memoryme.upload.api.dto.ImageUploadResponse;
+import memme.memoryme.upload.api.dto.VideoUploadResponse;
+import memme.memoryme.upload.config.S3StorageProperties;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+public class S3UploadService implements UploadService {
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final S3StorageProperties properties;
+    private final CurrentUserProvider currentUserProvider;
+    private final S3ObjectUrlBuilder objectUrlBuilder;
+
+    @Override
+    public ImageUploadResponse uploadImages(List<MultipartFile> files) {
+        if (files == null || files.isEmpty() || files.size() > 10) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+
+        List<StoredS3File> storedFiles = files.stream()
+                .map(file -> upload(file, "images", "image/"))
+                .toList();
+
+        return new ImageUploadResponse(
+                storedFiles.stream().map(StoredS3File::url).toList(),
+                storedFiles.stream().map(StoredS3File::key).toList()
+        );
+    }
+
+    @Override
+    public VideoUploadResponse uploadVideo(MultipartFile file) {
+        StoredS3File storedFile = upload(file, "videos", "video/");
+        return new VideoUploadResponse(
+                storedFile.url(),
+                storedFile.key(),
+                null,
+                null,
+                storedFile.size()
+        );
+    }
+
+    @Override
+    public FileUploadResponse uploadFile(MultipartFile file) {
+        StoredS3File storedFile = upload(file, "files", null);
+        return new FileUploadResponse(
+                storedFile.uid(),
+                storedFile.originalName(),
+                storedFile.url(),
+                storedFile.key(),
+                storedFile.mimeType(),
+                storedFile.size()
+        );
+    }
+
+    @Override
+    public String createReadUrl(String key) {
+        validateReadableKey(key);
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(properties.getS3().getBucket())
+                .key(key)
+                .build();
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(properties.getS3().getReadUrlExpireMinutes()))
+                .getObjectRequest(getObjectRequest)
+                .build();
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+    private StoredS3File upload(MultipartFile file, String directory, String requiredContentTypePrefix) {
+        validateFile(file, requiredContentTypePrefix);
+
+        UUID userUid = currentUserProvider.getUid();
+        UUID attachmentUid = UUID.randomUUID();
+        String originalName = sanitizeOriginalName(file.getOriginalFilename());
+        String extension = extension(originalName);
+        String key = buildKey(userUid, directory, attachmentUid, extension);
+        String mimeType = file.getContentType() == null || file.getContentType().isBlank()
+                ? "application/octet-stream"
+                : file.getContentType();
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(properties.getS3().getBucket())
+                    .key(key)
+                    .contentType(mimeType)
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            return new StoredS3File(
+                    attachmentUid,
+                    originalName,
+                    objectUrlBuilder.build(key),
+                    key,
+                    mimeType,
+                    file.getSize()
+            );
+        } catch (IOException e) {
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void validateFile(MultipartFile file, String requiredContentTypePrefix) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+        if (requiredContentTypePrefix == null) {
+            return;
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.toLowerCase(Locale.ROOT).startsWith(requiredContentTypePrefix)) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+    }
+
+    private String buildKey(UUID userUid, String directory, UUID attachmentUid, String extension) {
+        return properties.normalizedBasePrefix()
+                + "/users/" + userUid
+                + "/" + directory
+                + "/" + attachmentUid
+                + extension;
+    }
+
+    private void validateReadableKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST);
+        }
+        UUID userUid = currentUserProvider.getUid();
+        String normalizedKey = key.trim();
+        String expectedPrefix = properties.normalizedBasePrefix() + "/users/" + userUid + "/";
+        if (!normalizedKey.startsWith(expectedPrefix) || normalizedKey.contains("..")) {
+            throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+    }
+
+    private String sanitizeOriginalName(String originalName) {
+        if (originalName == null || originalName.isBlank()) {
+            return "file";
+        }
+
+        String sanitized = originalName.replaceAll("[\\r\\n\\t]", "_").trim();
+        int slash = Math.max(sanitized.lastIndexOf('/'), sanitized.lastIndexOf('\\'));
+
+        return slash >= 0 ? sanitized.substring(slash + 1) : sanitized;
+    }
+
+    private String extension(String originalName) {
+        if (originalName == null || !originalName.contains(".")) {
+            return "";
+        }
+        String extension = originalName.substring(originalName.lastIndexOf('.')).toLowerCase(Locale.ROOT);
+        if (!extension.matches("\\.[a-z0-9]{1,20}")) {
+            return "";
+        }
+        return extension;
+    }
+
+    private record StoredS3File(UUID uid, String originalName, String url, String key, String mimeType, Long size) {
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/UploadService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/UploadService.java
@@ -11,4 +11,5 @@ public interface UploadService {
     ImageUploadResponse uploadImages(List<MultipartFile> files);
     VideoUploadResponse uploadVideo(MultipartFile file);
     FileUploadResponse uploadFile(MultipartFile file);
+    String createReadUrl(String key);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/upload/config/S3StorageProperties.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/config/S3StorageProperties.java
@@ -1,0 +1,38 @@
+package memme.memoryme.upload.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cloud.aws")
+public class S3StorageProperties {
+    private final S3 s3 = new S3();
+    private final Credentials credentials = new Credentials();
+
+    @Getter
+    @Setter
+    public static class S3 {
+        private String bucket;
+        private String region = "ap-northeast-2";
+        private String basePrefix = "memme";
+        private long readUrlExpireMinutes = 10;
+    }
+
+    @Getter
+    @Setter
+    public static class Credentials {
+        private String accessKey;
+        private String secretKey;
+    }
+
+    public String normalizedBasePrefix() {
+        if (s3.basePrefix == null || s3.basePrefix.isBlank()) {
+            return "memme";
+        }
+        return s3.basePrefix.trim().replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+}

--- a/MemoryMe/src/main/resources/application-prod.yaml
+++ b/MemoryMe/src/main/resources/application-prod.yaml
@@ -90,6 +90,16 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000
 
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      region: ${AWS_REGION}
+      base-prefix: ${AWS_S3_BASE}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+
 # spring:
 #   web:
 #     error:


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
기존 로컬 uploads 저장 방식을 S3 기반 업로드 구조로 변경

- S3 클라이언트 및 스토리지 설정 추가
- 이미지, 영상, 파일 업로드를 S3 저장 방식으로 변경
- 노트 첨부파일에 S3 key, bucket, userUid, status 필드 추가
- 업로드 API에서 S3 객체 접근 URL 반환
- S3 기반 노트 첨부파일 저장 흐름 반영
- local-upload 프로필에서만 로컬 업로드 구현 사용
- 첨부파일 enum 및 S3 key 컬럼 매핑 문제 수정

### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
