### PR TITLE
feat(timeline): cursor slice 조회 및 첨부 URL 응답 개선

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/api/dto/BoardDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/dto/BoardDto.java
@@ -3,10 +3,12 @@ package memme.memoryme.board.api.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import memme.memoryme.board.domain.Board;
 import memme.memoryme.note.api.dto.NoteDto;
+import memme.memoryme.note.domain.NoteAttachment;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 @Schema(description = "보드 응답 DTO")
 public record BoardDto(
@@ -30,13 +32,17 @@ public record BoardDto(
         LocalDateTime updatedAt
 ) {
     public static BoardDto from(Board board) {
+        return from(board, null);
+    }
+
+    public static BoardDto from(Board board, Function<NoteAttachment, String> attachmentUrlResolver) {
         return new BoardDto(
                 board.getUid(),
                 "board",
                 board.getTitle(),
                 board.getDescription(),
                 List.copyOf(board.getTags()),
-                board.getNotes().stream().map(NoteDto::from).toList(),
+                board.getNotes().stream().map(note -> NoteDto.from(note, attachmentUrlResolver)).toList(),
                 board.isBookmarked(),
                 board.getCreatedAt(),
                 board.getUpdatedAt()

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -14,6 +14,7 @@ import memme.memoryme.note.domain.Note;
 import memme.memoryme.note.domain.NoteAttachment;
 import memme.memoryme.note.infra.repository.NoteRepository;
 import memme.memoryme.upload.application.service.S3ObjectUrlBuilder;
+import memme.memoryme.upload.application.service.UploadService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class BoardServiceImpl implements BoardService {
     private final CurrentUserProvider currentUserProvider;
     private final UserReader userReader;
     private final S3ObjectUrlBuilder objectUrlBuilder;
+    private final UploadService uploadService;
 
     @Override
     @Transactional
@@ -47,13 +49,13 @@ public class BoardServiceImpl implements BoardService {
                 .bookmarked(false)
                 .build();
 
-        return BoardDto.from(boardRepository.saveAndFlush(board));
+        return BoardDto.from(boardRepository.saveAndFlush(board), this::resolveAttachmentUrl);
     }
 
     @Override
     @Transactional(readOnly = true)
     public BoardDto getBoard(UUID boardUid) {
-        return BoardDto.from(getCurrentUserBoard(boardUid));
+        return BoardDto.from(getCurrentUserBoard(boardUid), this::resolveAttachmentUrl);
     }
 
     @Override
@@ -71,7 +73,7 @@ public class BoardServiceImpl implements BoardService {
                 normalizeTags(request.tags())
         );
         boardRepository.flush();
-        return BoardDto.from(board);
+        return BoardDto.from(board, this::resolveAttachmentUrl);
     }
 
     @Override
@@ -89,7 +91,7 @@ public class BoardServiceImpl implements BoardService {
         Board board = getCurrentUserBoard(boardUid);
         board.changeBookmarked(request != null && request.valueOrFalse());
         boardRepository.flush();
-        return BoardDto.from(board);
+        return BoardDto.from(board, this::resolveAttachmentUrl);
     }
 
     @Override
@@ -115,7 +117,7 @@ public class BoardServiceImpl implements BoardService {
         note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
         board.addNote(note);
         boardRepository.flush();
-        return NoteDto.from(note);
+        return NoteDto.from(note, this::resolveAttachmentUrl);
     }
 
     @Override
@@ -140,7 +142,7 @@ public class BoardServiceImpl implements BoardService {
         note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
         board.touch();
         boardRepository.flush();
-        return NoteDto.from(note);
+        return NoteDto.from(note, this::resolveAttachmentUrl);
     }
 
     @Override
@@ -172,7 +174,7 @@ public class BoardServiceImpl implements BoardService {
         targetBoard.addNote(note);
         boardRepository.flush();
 
-        return new MoveNoteResponse(BoardDto.from(sourceBoard), BoardDto.from(targetBoard));
+        return new MoveNoteResponse(BoardDto.from(sourceBoard, this::resolveAttachmentUrl), BoardDto.from(targetBoard, this::resolveAttachmentUrl));
     }
 
     private Board getCurrentUserBoard(UUID boardUid) {
@@ -334,5 +336,12 @@ public class BoardServiceImpl implements BoardService {
 
     private String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private String resolveAttachmentUrl(NoteAttachment attachment) {
+        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+            return attachment.getUrl();
+        }
+        return uploadService.createReadUrl(attachment.getS3Key());
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
@@ -14,6 +14,8 @@ import memme.memoryme.memo.domain.Memo;
 import memme.memoryme.memo.exception.MemoErrorCode;
 import memme.memoryme.memo.infra.repository.MemoRepository;
 import memme.memoryme.note.domain.Note;
+import memme.memoryme.note.domain.NoteAttachment;
+import memme.memoryme.upload.application.service.UploadService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class MemoServiceImpl implements MemoService {
     private final BoardRepository boardRepository;
     private final CurrentUserProvider currentUserProvider;
     private final UserReader userReader;
+    private final UploadService uploadService;
 
     @Override
     @Transactional
@@ -94,7 +97,7 @@ public class MemoServiceImpl implements MemoService {
         Board savedBoard = boardRepository.saveAndFlush(board);
         memoRepository.delete(memo);
         memoRepository.flush();
-        return BoardDto.from(savedBoard);
+        return BoardDto.from(savedBoard, this::resolveAttachmentUrl);
     }
 
     @Override
@@ -111,7 +114,7 @@ public class MemoServiceImpl implements MemoService {
         boardRepository.flush();
         memoRepository.delete(memo);
         memoRepository.flush();
-        return BoardDto.from(board);
+        return BoardDto.from(board, this::resolveAttachmentUrl);
     }
 
     private Memo getCurrentUserMemo(UUID memoUid, UUID userUid) {
@@ -175,5 +178,12 @@ public class MemoServiceImpl implements MemoService {
 
     private String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private String resolveAttachmentUrl(NoteAttachment attachment) {
+        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+            return attachment.getUrl();
+        }
+        return uploadService.createReadUrl(attachment.getS3Key());
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/AttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/AttachmentDto.java
@@ -8,6 +8,7 @@ import memme.memoryme.note.domain.NoteAttachment;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.function.Function;
 
 @Schema(description = "첨부파일 응답 DTO")
 public record AttachmentDto(
@@ -37,13 +38,17 @@ public record AttachmentDto(
         LocalDateTime createdAt
 ) {
     public static AttachmentDto from(NoteAttachment attachment) {
+        return from(attachment, null);
+    }
+
+    public static AttachmentDto from(NoteAttachment attachment, Function<NoteAttachment, String> urlResolver) {
         Note note = attachment.getNote();
         Board board = note == null ? null : note.getBoard();
         return new AttachmentDto(
                 attachment.getUid(),
                 attachment.getType(),
                 attachment.getOriginalName(),
-                attachment.getUrl(),
+                urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment),
                 attachment.getS3Key(),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
@@ -5,6 +5,7 @@ import memme.memoryme.note.domain.AttachmentType;
 import memme.memoryme.note.domain.NoteAttachment;
 
 import java.util.UUID;
+import java.util.function.Function;
 
 @Schema(description = "첨부 파일 DTO")
 public record FileAttachmentDto(
@@ -26,10 +27,14 @@ public record FileAttachmentDto(
         Integer duration
 ) {
     public static FileAttachmentDto from(NoteAttachment attachment) {
+        return from(attachment, null);
+    }
+
+    public static FileAttachmentDto from(NoteAttachment attachment, Function<NoteAttachment, String> urlResolver) {
         return new FileAttachmentDto(
                 attachment.getUid(),
                 attachment.getOriginalName(),
-                attachment.getUrl(),
+                urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment),
                 attachment.getS3Key(),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
@@ -8,6 +8,7 @@ import memme.memoryme.note.domain.NoteAttachment;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 @Schema(description = "노트 응답 DTO")
 public record NoteDto(
@@ -19,8 +20,12 @@ public record NoteDto(
         String content,
         @Schema(description = "첨부 이미지 URL 목록")
         List<String> imageUris,
+        @Schema(description = "첨부 이미지 S3 key 목록")
+        List<String> imageKeys,
         @Schema(description = "첨부 영상 URL 목록")
         List<String> videoUris,
+        @Schema(description = "첨부 영상 S3 key 목록")
+        List<String> videoKeys,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
         @Schema(description = "링크 URL")
@@ -33,26 +38,42 @@ public record NoteDto(
         LocalDateTime updatedAt
 ) {
     public static NoteDto from(Note note) {
+        return from(note, null);
+    }
+
+    public static NoteDto from(Note note, Function<NoteAttachment, String> urlResolver) {
         return new NoteDto(
                 note.getUid(),
                 note.getTitle(),
                 note.getContent(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.IMAGE)
-                        .map(NoteAttachment::getUrl)
+                        .map(attachment -> resolveUrl(attachment, urlResolver))
+                        .toList(),
+                note.getAttachments().stream()
+                        .filter(attachment -> attachment.getType() == AttachmentType.IMAGE)
+                        .map(NoteAttachment::getS3Key)
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.VIDEO)
-                        .map(NoteAttachment::getUrl)
+                        .map(attachment -> resolveUrl(attachment, urlResolver))
+                        .toList(),
+                note.getAttachments().stream()
+                        .filter(attachment -> attachment.getType() == AttachmentType.VIDEO)
+                        .map(NoteAttachment::getS3Key)
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.FILE)
-                        .map(FileAttachmentDto::from)
+                        .map(attachment -> FileAttachmentDto.from(attachment, urlResolver))
                         .toList(),
                 note.getUrl(),
                 OgDataDto.from(note),
                 note.getCreatedAt(),
                 note.getUpdatedAt()
         );
+    }
+
+    private static String resolveUrl(NoteAttachment attachment, Function<NoteAttachment, String> urlResolver) {
+        return urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment);
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/application/service/AttachmentServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/application/service/AttachmentServiceImpl.java
@@ -44,7 +44,7 @@ public class AttachmentServiceImpl implements AttachmentService {
         );
 
         return new AttachmentListResponse(
-                attachments.getContent().stream().map(AttachmentDto::from).toList(),
+                attachments.getContent().stream().map(attachment -> AttachmentDto.from(attachment, this::resolveAttachmentUrl)).toList(),
                 attachments.getTotalElements(),
                 normalizedPage,
                 normalizedLimit
@@ -54,7 +54,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     @Override
     @Transactional(readOnly = true)
     public AttachmentDto getAttachment(UUID attachmentUid) {
-        return AttachmentDto.from(getCurrentUserAttachment(attachmentUid));
+        return AttachmentDto.from(getCurrentUserAttachment(attachmentUid), this::resolveAttachmentUrl);
     }
 
     @Override
@@ -93,5 +93,12 @@ public class AttachmentServiceImpl implements AttachmentService {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(AttachmentErrorCode.INVALID_ATTACHMENT_REQUEST);
         }
+    }
+
+    private String resolveAttachmentUrl(NoteAttachment attachment) {
+        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+            return attachment.getUrl();
+        }
+        return uploadService.createReadUrl(attachment.getS3Key());
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/timeline/api/controller/TimelineController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/timeline/api/controller/TimelineController.java
@@ -28,14 +28,14 @@ public class TimelineController {
             @RequestParam(required = false) String tags,
             @RequestParam(required = false) String q,
             @RequestParam(required = false, defaultValue = "createdAt") String sort,
-            @RequestParam(required = false, defaultValue = "1") Integer page,
+            @RequestParam(required = false) String cursor,
             @RequestParam(required = false, defaultValue = "50") Integer limit,
             @RequestParam(required = false) UUID excludeId
     ) {
         return ResponseEntity.ok(ResponseWrapper.ok(
                 200,
                 "타임라인 조회 성공",
-                timelineService.getTimeline(type, tags, q, sort, page, limit, excludeId)
+                timelineService.getTimeline(type, tags, q, sort, cursor, limit, excludeId)
         ));
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/timeline/api/dto/TimelineResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/timeline/api/dto/TimelineResponse.java
@@ -8,11 +8,11 @@ import java.util.List;
 public record TimelineResponse(
         @Schema(description = "메모와 보드가 섞인 타임라인 항목")
         List<Object> items,
-        @Schema(description = "전체 개수", example = "120")
-        long total,
-        @Schema(description = "현재 페이지", example = "1")
-        int page,
-        @Schema(description = "페이지 크기", example = "50")
+        @Schema(description = "다음 slice 존재 여부", example = "true")
+        boolean hasNext,
+        @Schema(description = "다음 slice 조회용 cursor")
+        String nextCursor,
+        @Schema(description = "요청 slice 크기", example = "50")
         int limit
 ) {
 }

--- a/MemoryMe/src/main/java/memme/memoryme/timeline/application/service/TimelineService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/timeline/application/service/TimelineService.java
@@ -9,13 +9,17 @@ import memme.memoryme.memo.api.dto.memo.MemoDto;
 import memme.memoryme.memo.domain.Memo;
 import memme.memoryme.memo.infra.repository.MemoRepository;
 import memme.memoryme.note.domain.Note;
+import memme.memoryme.note.domain.NoteAttachment;
 import memme.memoryme.timeline.api.dto.TimelineResponse;
 import memme.memoryme.global.exception.BusinessException;
 import memme.memoryme.timeline.exception.TimelineErrorCode;
+import memme.memoryme.upload.application.service.UploadService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @Service
@@ -24,17 +28,18 @@ public class TimelineService {
     private final MemoRepository memoRepository;
     private final BoardRepository boardRepository;
     private final CurrentUserProvider currentUserProvider;
+    private final UploadService uploadService;
 
     @Transactional(readOnly = true)
-    public TimelineResponse getTimeline(String type, String tags, String q, String sort, Integer page, Integer limit, UUID excludeId) {
+    public TimelineResponse getTimeline(String type, String tags, String q, String sort, String cursor, Integer limit, UUID excludeId) {
         UUID userUid = currentUserProvider.getUid();
-        int normalizedPage = page == null || page < 1 ? 1 : page;
         int normalizedLimit = limit == null || limit < 1 ? 50 : Math.min(limit, 100);
         String normalizedType = normalize(type);
         String keyword = normalize(q);
         Set<String> tagSet = parseTags(tags);
         validateType(normalizedType);
         validateSort(sort);
+        TimelineCursor decodedCursor = decodeCursor(cursor);
 
         List<TimelineItem> items = new ArrayList<>();
 
@@ -43,7 +48,7 @@ public class TimelineService {
                 memoRepository.findAllByUserUid(userUid).stream()
                         .filter(memo -> excludeId == null || !memo.getUid().equals(excludeId))
                         .filter(memo -> keyword == null || contains(memo.getText(), keyword))
-                        .map(memo -> new TimelineItem(MemoDto.from(memo), "memo", memo.getCreatedAt(), memo.getCreatedAt()))
+                        .map(memo -> new TimelineItem(MemoDto.from(memo), memo.getUid(), memo.getCreatedAt(), memo.getCreatedAt()))
                         .forEach(items::add);
             }
         }
@@ -53,7 +58,7 @@ public class TimelineService {
                     .filter(board -> excludeId == null || !board.getUid().equals(excludeId))
                     .filter(board -> tagSet.isEmpty() || board.getTags().containsAll(tagSet))
                     .filter(board -> keyword == null || boardMatches(board, keyword))
-                    .map(board -> new TimelineItem(BoardDto.from(board), "board", board.getCreatedAt(), board.getUpdatedAt()))
+                    .map(board -> new TimelineItem(BoardDto.from(board, this::resolveAttachmentUrl), board.getUid(), board.getCreatedAt(), board.getUpdatedAt()))
                     .forEach(items::add);
         }
 
@@ -62,13 +67,19 @@ public class TimelineService {
                 : Comparator.comparing(TimelineItem::createdAt);
         items.sort(comparator.reversed());
 
-        int fromIndex = Math.min((normalizedPage - 1) * normalizedLimit, items.size());
-        int toIndex = Math.min(fromIndex + normalizedLimit, items.size());
+        int fromIndex = cursorStartIndex(items, decodedCursor, sort);
+        int toIndex = Math.min(fromIndex + normalizedLimit + 1, items.size());
+        List<TimelineItem> slice = items.subList(fromIndex, toIndex);
+        boolean hasNext = slice.size() > normalizedLimit;
+        List<TimelineItem> visibleItems = hasNext ? slice.subList(0, normalizedLimit) : slice;
+        String nextCursor = hasNext && !visibleItems.isEmpty()
+                ? encodeCursor(visibleItems.get(visibleItems.size() - 1), sort)
+                : null;
 
         return new TimelineResponse(
-                items.subList(fromIndex, toIndex).stream().map(TimelineItem::data).toList(),
-                items.size(),
-                normalizedPage,
+                visibleItems.stream().map(TimelineItem::data).toList(),
+                hasNext,
+                nextCursor,
                 normalizedLimit
         );
     }
@@ -125,6 +136,55 @@ public class TimelineService {
         }
     }
 
-    private record TimelineItem(Object data, String type, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private int cursorStartIndex(List<TimelineItem> items, TimelineCursor cursor, String sort) {
+        if (cursor == null) {
+            return 0;
+        }
+        for (int i = 0; i < items.size(); i++) {
+            TimelineItem item = items.get(i);
+            if (item.uid().equals(cursor.uid())) {
+                return i + 1;
+            }
+        }
+        for (int i = 0; i < items.size(); i++) {
+            if (items.get(i).sortAt(sort).isBefore(cursor.sortAt())) {
+                return i;
+            }
+        }
+        return items.size();
+    }
+
+    private String encodeCursor(TimelineItem item, String sort) {
+        String payload = item.sortAt(sort).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "|" + item.uid();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private TimelineCursor decodeCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            String payload = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            String[] parts = payload.split("\\|", 2);
+            return new TimelineCursor(LocalDateTime.parse(parts[0], DateTimeFormatter.ISO_LOCAL_DATE_TIME), UUID.fromString(parts[1]));
+        } catch (RuntimeException e) {
+            throw new BusinessException(TimelineErrorCode.INVALID_TIMELINE_REQUEST);
+        }
+    }
+
+    private String resolveAttachmentUrl(NoteAttachment attachment) {
+        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+            return attachment.getUrl();
+        }
+        return uploadService.createReadUrl(attachment.getS3Key());
+    }
+
+    private record TimelineCursor(LocalDateTime sortAt, UUID uid) {
+    }
+
+    private record TimelineItem(Object data, UUID uid, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        private LocalDateTime sortAt(String sort) {
+            return "updatedAt".equals(sort) ? updatedAt : createdAt;
+        }
     }
 }


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- 타임라인 응답을 page 기반에서 cursor slice 기반으로 변경

- 응답에 hasNext, nextCursor를 추가해 채팅형 목록 조회 흐름 지원

- 노트, 보드, 첨부 응답에서 S3 key와 presigned view URL을 함께 제공

- 파일 첨부 URL도 화면에서 바로 렌더링 가능한 접근 URL로 변환


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [ ] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
