### PR TITLE
fix(upload): 조회 응답 첨부 URL 정규화

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -266,14 +266,18 @@ public class BoardServiceImpl implements BoardService {
         }
         urls.stream()
                 .filter(url -> url != null && !url.isBlank())
-                .map(url -> NoteAttachment.builder()
+                .map(url -> {
+                    String value = url.trim();
+                    String key = extractKey(value);
+                    return NoteAttachment.builder()
                         .uid(UUID.randomUUID())
                         .userUid(userUid)
                         .type(type)
                         .originalName(originalName)
-                        .url(url.trim())
-                        .s3Key(extractKeyFromObjectUrl(url.trim()))
-                        .build())
+                        .url(key == null ? value : objectUrlBuilder.build(key))
+                        .s3Key(key)
+                        .build();
+                })
                 .forEach(attachments::add);
     }
 
@@ -301,7 +305,10 @@ public class BoardServiceImpl implements BoardService {
             url = objectUrlBuilder.build(key);
         }
         if (key == null && url != null) {
-            key = extractKeyFromObjectUrl(url);
+            key = extractKey(url);
+        }
+        if (key != null) {
+            url = objectUrlBuilder.build(key);
         }
         return NoteAttachment.builder()
                 .uid(file.uid() != null ? file.uid() : UUID.randomUUID())
@@ -334,14 +341,36 @@ public class BoardServiceImpl implements BoardService {
         return java.net.URLDecoder.decode(encodedKey, java.nio.charset.StandardCharsets.UTF_8);
     }
 
+    private String extractKey(String value) {
+        String key = extractKeyFromObjectUrl(value);
+        if (key != null) {
+            return key;
+        }
+        String normalized = blankToNull(value);
+        return isS3ObjectKey(normalized) ? normalized : null;
+    }
+
+    private boolean isS3ObjectKey(String value) {
+        return value != null
+                && !value.startsWith("/")
+                && !value.startsWith("http://")
+                && !value.startsWith("https://")
+                && value.contains("/users/")
+                && (value.contains("/images/") || value.contains("/videos/") || value.contains("/files/"));
+    }
+
     private String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value.trim();
     }
 
     private String resolveAttachmentUrl(NoteAttachment attachment) {
-        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+        String key = blankToNull(attachment.getS3Key());
+        if (key == null) {
+            key = extractKey(attachment.getUrl());
+        }
+        if (key == null) {
             return attachment.getUrl();
         }
-        return uploadService.createReadUrl(attachment.getS3Key());
+        return uploadService.createReadUrl(key);
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
@@ -181,9 +181,28 @@ public class MemoServiceImpl implements MemoService {
     }
 
     private String resolveAttachmentUrl(NoteAttachment attachment) {
-        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+        String key = resolveAttachmentKey(attachment);
+        if (key == null) {
             return attachment.getUrl();
         }
-        return uploadService.createReadUrl(attachment.getS3Key());
+        return uploadService.createReadUrl(key);
+    }
+
+    private String resolveAttachmentKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key().trim();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/AttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/AttachmentDto.java
@@ -49,7 +49,7 @@ public record AttachmentDto(
                 attachment.getType(),
                 attachment.getOriginalName(),
                 urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment),
-                attachment.getS3Key(),
+                resolveKey(attachment),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),
                 attachment.getThumbnailUrl(),
@@ -58,5 +58,23 @@ public record AttachmentDto(
                 board == null ? null : board.getUid(),
                 attachment.getCreatedAt()
         );
+    }
+
+    private static String resolveKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/FileAttachmentDto.java
@@ -35,7 +35,7 @@ public record FileAttachmentDto(
                 attachment.getUid(),
                 attachment.getOriginalName(),
                 urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment),
-                attachment.getS3Key(),
+                resolveKey(attachment),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),
                 attachment.getThumbnailUrl(),
@@ -60,5 +60,23 @@ public record FileAttachmentDto(
                 .thumbnailUrl(thumbnailUrl)
                 .durationSeconds(duration)
                 .build();
+    }
+
+    private static String resolveKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MediaAttachmentDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MediaAttachmentDto.java
@@ -27,11 +27,29 @@ public record MediaAttachmentDto(
         return new MediaAttachmentDto(
                 attachment.getUid(),
                 urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment),
-                attachment.getS3Key(),
+                resolveKey(attachment),
                 attachment.getMimeType(),
                 attachment.getSizeBytes(),
                 attachment.getThumbnailUrl(),
                 attachment.getDurationSeconds()
         );
+    }
+
+    private static String resolveKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
@@ -56,7 +56,7 @@ public record NoteDto(
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.IMAGE)
-                        .map(NoteAttachment::getS3Key)
+                        .map(NoteDto::resolveKey)
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.IMAGE)
@@ -68,7 +68,7 @@ public record NoteDto(
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.VIDEO)
-                        .map(NoteAttachment::getS3Key)
+                        .map(NoteDto::resolveKey)
                         .toList(),
                 note.getAttachments().stream()
                         .filter(attachment -> attachment.getType() == AttachmentType.VIDEO)
@@ -87,5 +87,23 @@ public record NoteDto(
 
     private static String resolveUrl(NoteAttachment attachment, Function<NoteAttachment, String> urlResolver) {
         return urlResolver == null ? attachment.getUrl() : urlResolver.apply(attachment);
+    }
+
+    private static String resolveKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/application/service/AttachmentServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/application/service/AttachmentServiceImpl.java
@@ -96,9 +96,28 @@ public class AttachmentServiceImpl implements AttachmentService {
     }
 
     private String resolveAttachmentUrl(NoteAttachment attachment) {
-        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+        String key = resolveAttachmentKey(attachment);
+        if (key == null) {
             return attachment.getUrl();
         }
-        return uploadService.createReadUrl(attachment.getS3Key());
+        return uploadService.createReadUrl(key);
+    }
+
+    private String resolveAttachmentKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key().trim();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/timeline/application/service/TimelineService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/timeline/application/service/TimelineService.java
@@ -173,10 +173,29 @@ public class TimelineService {
     }
 
     private String resolveAttachmentUrl(NoteAttachment attachment) {
-        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+        String key = resolveAttachmentKey(attachment);
+        if (key == null) {
             return attachment.getUrl();
         }
-        return uploadService.createReadUrl(attachment.getS3Key());
+        return uploadService.createReadUrl(key);
+    }
+
+    private String resolveAttachmentKey(NoteAttachment attachment) {
+        if (attachment.getS3Key() != null && !attachment.getS3Key().isBlank()) {
+            return attachment.getS3Key().trim();
+        }
+        String url = attachment.getUrl();
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String normalized = url.trim();
+        if (normalized.startsWith("http://") || normalized.startsWith("https://") || normalized.startsWith("/")) {
+            return null;
+        }
+        return normalized.contains("/users/")
+                && (normalized.contains("/images/") || normalized.contains("/videos/") || normalized.contains("/files/"))
+                ? normalized
+                : null;
     }
 
     private record TimelineCursor(LocalDateTime sortAt, UUID uid) {

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3UploadService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/S3UploadService.java
@@ -214,7 +214,7 @@ public class S3UploadService implements UploadService {
                     .filter(object -> !object.key().endsWith("/"))
                     .map(object -> new UploadObjectDto(
                             directory,
-                            objectUrlBuilder.build(object.key()),
+                            createReadUrl(object.key()),
                             object.key(),
                             object.size(),
                             object.lastModified()


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- 기존 이미지 첨부에 raw S3 key가 저장된 경우 presigned URL로 변환

- 이미지, 영상, 파일 응답의 key 필드를 기존 데이터에서도 복원

- 업로드 객체 목록 조회 응답도 바로 접근 가능한 presigned URL로 변경

- 신규 노트 저장 시 raw S3 key 입력을 s3Key로 정규화


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
