### PR TITLE
feat(note): 노트 URL 및 OG 데이터 복수 필드 지원 추가

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -103,15 +103,16 @@ public class BoardServiceImpl implements BoardService {
         Board board = getCurrentUserBoard(boardUid);
         validateNoteTitle(request.title());
 
+        OgDataDto ogData = resolveOgData(request.ogDatas(), request.ogData());
         Note note = Note.builder()
                 .uid(UUID.randomUUID())
                 .title(request.title().trim())
                 .content(blankToNull(request.content()))
-                .url(blankToNull(request.url()))
-                .ogTitle(request.ogData() != null ? blankToNull(request.ogData().title()) : null)
-                .ogDescription(request.ogData() != null ? blankToNull(request.ogData().description()) : null)
-                .ogImageUrl(request.ogData() != null ? blankToNull(request.ogData().imageUrl()) : null)
-                .ogSiteName(request.ogData() != null ? blankToNull(request.ogData().siteName()) : null)
+                .url(blankToNull(resolveFirstUrl(request.urls(), request.url())))
+                .ogTitle(ogData != null ? blankToNull(ogData.title()) : null)
+                .ogDescription(ogData != null ? blankToNull(ogData.description()) : null)
+                .ogImageUrl(ogData != null ? blankToNull(ogData.imageUrl()) : null)
+                .ogSiteName(ogData != null ? blankToNull(ogData.siteName()) : null)
                 .build();
 
         note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
@@ -130,14 +131,15 @@ public class BoardServiceImpl implements BoardService {
         Note note = findNote(board, noteUid);
         validateNoteTitle(request.title());
 
+        OgDataDto ogData = resolveOgData(request.ogDatas(), request.ogData());
         note.update(
                 request.title().trim(),
                 blankToNull(request.content()),
-                blankToNull(request.url()),
-                request.ogData() != null ? blankToNull(request.ogData().title()) : null,
-                request.ogData() != null ? blankToNull(request.ogData().description()) : null,
-                request.ogData() != null ? blankToNull(request.ogData().imageUrl()) : null,
-                request.ogData() != null ? blankToNull(request.ogData().siteName()) : null
+                blankToNull(resolveFirstUrl(request.urls(), request.url())),
+                ogData != null ? blankToNull(ogData.title()) : null,
+                ogData != null ? blankToNull(ogData.description()) : null,
+                ogData != null ? blankToNull(ogData.imageUrl()) : null,
+                ogData != null ? blankToNull(ogData.siteName()) : null
         );
         note.replaceAttachments(toAttachments(board.getUserUid(), request.imageUris(), request.imageKeys(), request.videoUris(), request.videoKeys(), request.files()));
         board.touch();
@@ -361,6 +363,24 @@ public class BoardServiceImpl implements BoardService {
 
     private String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private String resolveFirstUrl(List<String> urls, String url) {
+        if (urls != null) {
+            for (String u : urls) {
+                if (u != null && !u.isBlank()) {
+                    return u;
+                }
+            }
+        }
+        return url;
+    }
+
+    private OgDataDto resolveOgData(List<OgDataDto> ogDatas, OgDataDto ogData) {
+        if (ogDatas != null && !ogDatas.isEmpty()) {
+            return ogDatas.get(0);
+        }
+        return ogData;
     }
 
     private String resolveAttachmentUrl(NoteAttachment attachment) {

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/CreateNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/CreateNoteRequest.java
@@ -20,9 +20,13 @@ public record CreateNoteRequest(
         List<String> videoKeys,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
-        @Schema(description = "링크 URL")
+        @Schema(description = "링크 URL 목록")
+        List<String> urls,
+        @Schema(description = "링크 URL (레거시)")
         String url,
-        @Schema(description = "OG 미리보기 데이터")
+        @Schema(description = "OG 미리보기 데이터 목록")
+        List<OgDataDto> ogDatas,
+        @Schema(description = "OG 미리보기 데이터 (레거시)")
         OgDataDto ogData
 ) {
 }

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
@@ -32,9 +32,13 @@ public record NoteDto(
         List<MediaAttachmentDto> videos,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
-        @Schema(description = "링크 URL")
+        @Schema(description = "링크 URL 목록")
+        List<String> urls,
+        @Schema(description = "링크 URL (레거시)")
         String url,
-        @Schema(description = "OG 미리보기 데이터")
+        @Schema(description = "OG 미리보기 데이터 목록")
+        List<OgDataDto> ogDatas,
+        @Schema(description = "OG 미리보기 데이터 (레거시)")
         OgDataDto ogData,
         @Schema(description = "생성 시각")
         LocalDateTime createdAt,
@@ -46,6 +50,8 @@ public record NoteDto(
     }
 
     public static NoteDto from(Note note, Function<NoteAttachment, String> urlResolver) {
+        String url = note.getUrl();
+        OgDataDto ogData = OgDataDto.from(note);
         return new NoteDto(
                 note.getUid(),
                 note.getTitle(),
@@ -78,8 +84,10 @@ public record NoteDto(
                         .filter(attachment -> attachment.getType() == AttachmentType.FILE)
                         .map(attachment -> FileAttachmentDto.from(attachment, urlResolver))
                         .toList(),
-                note.getUrl(),
-                OgDataDto.from(note),
+                url != null ? List.of(url) : List.of(),
+                url,
+                ogData != null ? List.of(ogData) : List.of(),
+                ogData,
                 note.getCreatedAt(),
                 note.getUpdatedAt()
         );

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/UpdateNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/UpdateNoteRequest.java
@@ -20,9 +20,13 @@ public record UpdateNoteRequest(
         List<String> videoKeys,
         @Schema(description = "첨부 파일 목록")
         List<FileAttachmentDto> files,
-        @Schema(description = "링크 URL")
+        @Schema(description = "링크 URL 목록")
+        List<String> urls,
+        @Schema(description = "링크 URL (레거시)")
         String url,
-        @Schema(description = "OG 미리보기 데이터")
+        @Schema(description = "OG 미리보기 데이터 목록")
+        List<OgDataDto> ogDatas,
+        @Schema(description = "OG 미리보기 데이터 (레거시)")
         OgDataDto ogData
 ) {
 }


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- NoteDto 응답에 urls(List), ogDatas(List) 필드 추가
- url, ogData 레거시 필드는 하위 호환성을 위해 유지
- CreateNoteRequest에 urls, ogDatas 요청 필드 추가
- UpdateNoteRequest에 urls, ogDatas 요청 필드 추가
- BoardServiceImpl에 resolveFirstUrl(), resolveOgData() 헬퍼 추가
- 노트 생성/수정 시 urls[0], ogDatas[0] 우선 사용, 없으면 레거시 url/ogData 폴백


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
