### PR TITLE
fix(note): 다중 링크 저장 및 조회 누락 수정

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -104,11 +104,13 @@ public class BoardServiceImpl implements BoardService {
         validateNoteTitle(request.title());
 
         OgDataDto ogData = resolveOgData(request.ogDatas(), request.ogData());
+        List<String> urls = resolveUrls(request.urls(), request.url());
         Note note = Note.builder()
                 .uid(UUID.randomUUID())
                 .title(request.title().trim())
                 .content(blankToNull(request.content()))
-                .url(blankToNull(resolveFirstUrl(request.urls(), request.url())))
+                .urls(urls)
+                .url(firstUrl(urls))
                 .ogTitle(ogData != null ? blankToNull(ogData.title()) : null)
                 .ogDescription(ogData != null ? blankToNull(ogData.description()) : null)
                 .ogImageUrl(ogData != null ? blankToNull(ogData.imageUrl()) : null)
@@ -135,7 +137,7 @@ public class BoardServiceImpl implements BoardService {
         note.update(
                 request.title().trim(),
                 blankToNull(request.content()),
-                blankToNull(resolveFirstUrl(request.urls(), request.url())),
+                resolveUrls(request.urls(), request.url()),
                 ogData != null ? blankToNull(ogData.title()) : null,
                 ogData != null ? blankToNull(ogData.description()) : null,
                 ogData != null ? blankToNull(ogData.imageUrl()) : null,
@@ -365,15 +367,24 @@ public class BoardServiceImpl implements BoardService {
         return value == null || value.isBlank() ? null : value.trim();
     }
 
-    private String resolveFirstUrl(List<String> urls, String url) {
+    private List<String> resolveUrls(List<String> urls, String url) {
+        LinkedHashSet<String> normalized = new LinkedHashSet<>();
         if (urls != null) {
             for (String u : urls) {
                 if (u != null && !u.isBlank()) {
-                    return u;
+                    normalized.add(u.trim());
                 }
             }
         }
-        return url;
+        String legacyUrl = blankToNull(url);
+        if (normalized.isEmpty() && legacyUrl != null) {
+            normalized.add(legacyUrl);
+        }
+        return new ArrayList<>(normalized);
+    }
+
+    private String firstUrl(List<String> urls) {
+        return urls == null || urls.isEmpty() ? null : urls.get(0);
     }
 
     private OgDataDto resolveOgData(List<OgDataDto> ogDatas, OgDataDto ogData) {

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/NoteDto.java
@@ -51,6 +51,9 @@ public record NoteDto(
 
     public static NoteDto from(Note note, Function<NoteAttachment, String> urlResolver) {
         String url = note.getUrl();
+        List<String> urls = note.getUrls().isEmpty()
+                ? (url != null ? List.of(url) : List.of())
+                : List.copyOf(note.getUrls());
         OgDataDto ogData = OgDataDto.from(note);
         return new NoteDto(
                 note.getUid(),
@@ -84,7 +87,7 @@ public record NoteDto(
                         .filter(attachment -> attachment.getType() == AttachmentType.FILE)
                         .map(attachment -> FileAttachmentDto.from(attachment, urlResolver))
                         .toList(),
-                url != null ? List.of(url) : List.of(),
+                urls,
                 url,
                 ogData != null ? List.of(ogData) : List.of(),
                 ogData,

--- a/MemoryMe/src/main/java/memme/memoryme/note/domain/Note.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/domain/Note.java
@@ -44,6 +44,13 @@ public class Note {
     @Column(length = 2048)
     private String url;
 
+    @ElementCollection
+    @CollectionTable(name = "note_url", joinColumns = @JoinColumn(name = "note_id"))
+    @Column(name = "url", nullable = false, length = 2048)
+    @OrderColumn(name = "sort_order")
+    @Builder.Default
+    private List<String> urls = new ArrayList<>();
+
     @Column(name = "og_title")
     private String ogTitle;
 
@@ -78,15 +85,23 @@ public class Note {
         this.sortOrder = sortOrder;
     }
 
-    public void update(String title, String content, String url, String ogTitle, String ogDescription, String ogImageUrl, String ogSiteName) {
+    public void update(String title, String content, List<String> urls, String ogTitle, String ogDescription, String ogImageUrl, String ogSiteName) {
         this.title = title;
         this.content = content;
-        this.url = url;
+        replaceUrls(urls);
         this.ogTitle = ogTitle;
         this.ogDescription = ogDescription;
         this.ogImageUrl = ogImageUrl;
         this.ogSiteName = ogSiteName;
         touch();
+    }
+
+    public void replaceUrls(List<String> urls) {
+        this.urls.clear();
+        if (urls != null) {
+            this.urls.addAll(urls);
+        }
+        this.url = this.urls.isEmpty() ? null : this.urls.get(0);
     }
 
     public void replaceAttachments(List<NoteAttachment> newAttachments) {


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- 노트 링크 목록을 note_url 컬렉션으로 저장하도록 추가
- 생성 및 수정 시 urls 배열 전체를 저장하도록 변경
- 응답 urls에 저장된 링크 전체를 반환하고 레거시 단일 url은 첫 링크로 유지


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
