### PR TITLE
feat(board): 다중 노트 이동 API 추가

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/api/controller/BoardController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/controller/BoardController.java
@@ -67,6 +67,11 @@ public class BoardController implements BoardApi {
     }
 
     @Override
+    public ResponseEntity<ResponseWrapper<MoveNoteResponse>> moveNotes(UUID boardUid, MoveNoteRequest request) {
+        return ResponseEntity.ok(ResponseWrapper.ok(200, "노트 이동 성공", boardService.moveNotes(boardUid, request)));
+    }
+
+    @Override
     public ResponseEntity<ResponseWrapper<MoveNoteResponse>> moveNote(UUID boardUid, UUID noteUid, MoveNoteRequest request) {
         return ResponseEntity.ok(ResponseWrapper.ok(200, "노트 이동 성공", boardService.moveNote(boardUid, noteUid, request)));
     }

--- a/MemoryMe/src/main/java/memme/memoryme/board/api/controller/api/BoardApi.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/controller/api/BoardApi.java
@@ -66,6 +66,13 @@ public interface BoardApi {
     );
 
     @Operation(summary = "노트 다른 보드로 이동")
+    @PatchMapping("/{boardUid}/notes/move")
+    ResponseEntity<ResponseWrapper<MoveNoteResponse>> moveNotes(
+            @PathVariable UUID boardUid,
+            @RequestBody MoveNoteRequest request
+    );
+
+    @Operation(summary = "노트 다른 보드로 이동 (단건 호환)")
     @PatchMapping("/{boardUid}/notes/{noteUid}/move")
     ResponseEntity<ResponseWrapper<MoveNoteResponse>> moveNote(
             @PathVariable UUID boardUid,

--- a/MemoryMe/src/main/java/memme/memoryme/board/api/dto/MoveNoteResponse.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/dto/MoveNoteResponse.java
@@ -2,8 +2,15 @@ package memme.memoryme.board.api.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+import java.util.UUID;
+
 @Schema(description = "노트 이동 응답 DTO")
 public record MoveNoteResponse(
+        @Schema(description = "이동된 노트 UID 목록")
+        List<UUID> movedNoteUids,
+        @Schema(description = "이동된 노트 개수")
+        int movedCount,
         @Schema(description = "노트가 제거된 원본 보드")
         BoardDto sourceBoard,
         @Schema(description = "노트가 추가된 대상 보드")

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardService.java
@@ -17,5 +17,6 @@ public interface BoardService {
     NoteDto createNote(UUID boardUid, CreateNoteRequest request);
     NoteDto updateNote(UUID boardUid, UUID noteUid, UpdateNoteRequest request);
     void deleteNote(UUID boardUid, UUID noteUid);
+    MoveNoteResponse moveNotes(UUID sourceBoardUid, MoveNoteRequest request);
     MoveNoteResponse moveNote(UUID sourceBoardUid, UUID noteUid, MoveNoteRequest request);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -161,9 +161,23 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
+    public MoveNoteResponse moveNotes(UUID sourceBoardUid, MoveNoteRequest request) {
+        return moveNotes(sourceBoardUid, null, request);
+    }
+
+    @Override
+    @Transactional
     public MoveNoteResponse moveNote(UUID sourceBoardUid, UUID noteUid, MoveNoteRequest request) {
+        return moveNotes(sourceBoardUid, noteUid, request);
+    }
+
+    private MoveNoteResponse moveNotes(UUID sourceBoardUid, UUID pathNoteUid, MoveNoteRequest request) {
         UUID targetBoardUid = request == null ? null : request.resolvedTargetBoardUid();
+        List<UUID> noteUids = request == null ? List.of() : request.resolvedNoteUids(pathNoteUid);
         if (targetBoardUid == null) {
+            throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
+        }
+        if (noteUids.isEmpty()) {
             throw new BusinessException(BoardErrorCode.INVALID_NOTE_REQUEST);
         }
         if (sourceBoardUid.equals(targetBoardUid)) {
@@ -172,13 +186,22 @@ public class BoardServiceImpl implements BoardService {
 
         Board sourceBoard = getCurrentUserBoard(sourceBoardUid);
         Board targetBoard = getCurrentUserBoard(targetBoardUid);
-        Note note = findNote(sourceBoard, noteUid);
+        List<Note> notes = noteUids.stream()
+                .map(noteUid -> findNote(sourceBoard, noteUid))
+                .toList();
 
-        sourceBoard.removeNote(note);
-        targetBoard.addNote(note);
+        notes.forEach(note -> {
+            sourceBoard.removeNote(note);
+            targetBoard.addNote(note);
+        });
         boardRepository.flush();
 
-        return new MoveNoteResponse(BoardDto.from(sourceBoard, this::resolveAttachmentUrl), BoardDto.from(targetBoard, this::resolveAttachmentUrl));
+        return new MoveNoteResponse(
+                noteUids,
+                noteUids.size(),
+                BoardDto.from(sourceBoard, this::resolveAttachmentUrl),
+                BoardDto.from(targetBoard, this::resolveAttachmentUrl)
+        );
     }
 
     private Board getCurrentUserBoard(UUID boardUid) {

--- a/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MoveNoteRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/api/dto/MoveNoteRequest.java
@@ -2,10 +2,19 @@ package memme.memoryme.note.api.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.UUID;
 
 @Schema(description = "노트 이동 요청 DTO")
 public record MoveNoteRequest(
+        @Schema(description = "이동할 노트 UID 목록")
+        List<UUID> noteUids,
+        @Schema(description = "이동할 노트 UID (단건 호환)")
+        UUID noteUid,
+        @Schema(description = "이동할 노트 UID (기존 프론트 호환)")
+        UUID noteId,
         @Schema(description = "대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID targetBoardUid,
         @Schema(description = "기존 프론트 호환용 대상 보드 UID", example = "550e8400-e29b-41d4-a716-446655440000")
@@ -26,5 +35,24 @@ public record MoveNoteRequest(
             return boardUid;
         }
         return boardId;
+    }
+
+    public List<UUID> resolvedNoteUids(UUID pathNoteUid) {
+        LinkedHashSet<UUID> resolved = new LinkedHashSet<>();
+        if (pathNoteUid != null) {
+            resolved.add(pathNoteUid);
+        }
+        if (noteUids != null) {
+            noteUids.stream()
+                    .filter(uid -> uid != null)
+                    .forEach(resolved::add);
+        }
+        if (noteUid != null) {
+            resolved.add(noteUid);
+        }
+        if (noteId != null) {
+            resolved.add(noteId);
+        }
+        return new ArrayList<>(resolved);
     }
 }


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- noteUids 배열 기반으로 여러 노트를 한 번에 다른 보드로 이동하도록 추가

- 단건 이동도 동일 요청 구조에서 처리하도록 noteUid 호환 필드 지원

- 이동 응답에 이동된 노트 UID 목록과 개수 추가

- 기존 단건 이동 엔드포인트는 호환용으로 동일 서비스 로직에 위임


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
