### PR TITLE
fix(og): YouTube 링크 메타데이터 추출 개선

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/og/application/service/OgService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/og/application/service/OgService.java
@@ -1,5 +1,7 @@
 package memme.memoryme.og.application.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import memme.memoryme.global.exception.BusinessException;
 import memme.memoryme.note.api.dto.OgDataDto;
 import memme.memoryme.og.exception.OgErrorCode;
@@ -7,12 +9,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.HtmlUtils;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -22,6 +27,7 @@ public class OgService {
     private static final int MAX_TITLE_LENGTH = 180;
     private static final int MAX_DESCRIPTION_LENGTH = 1000;
     private final OpenAiSummaryService openAiSummaryService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(3))
             .followRedirects(HttpClient.Redirect.NORMAL)
@@ -55,6 +61,11 @@ public class OgService {
     private OgFetchResult fetchResult(String url) {
         if (!isHttpUrl(url)) {
             throw new BusinessException(OgErrorCode.INVALID_OG_REQUEST);
+        }
+
+        OgFetchResult youtubeResult = fetchYoutubeOEmbed(url);
+        if (youtubeResult != null) {
+            return youtubeResult;
         }
 
         try {
@@ -96,6 +107,80 @@ public class OgService {
             }
             return null;
         }
+    }
+
+    private OgFetchResult fetchYoutubeOEmbed(String url) {
+        if (!isYoutubeUrl(url)) {
+            return null;
+        }
+        try {
+            String encodedUrl = URLEncoder.encode(url.trim(), StandardCharsets.UTF_8);
+            URI uri = URI.create("https://www.youtube.com/oembed?format=json&url=" + encodedUrl);
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                    .timeout(Duration.ofSeconds(5))
+                    .header("User-Agent", "MemoryMeBot/1.0")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return null;
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            String title = cleanText(root.path("title").asText(null));
+            String author = cleanText(root.path("author_name").asText(null));
+            String thumbnailUrl = cleanText(root.path("thumbnail_url").asText(null));
+            if (title == null) {
+                return null;
+            }
+
+            String description = author == null ? null : "채널: " + author;
+            String sourceText = youtubeSourceText(url, title, author);
+            return new OgFetchResult(
+                    new OgDataDto(
+                            abbreviate(title, MAX_TITLE_LENGTH),
+                            description,
+                            thumbnailUrl,
+                            "YouTube",
+                            null
+                    ),
+                    sourceText
+            );
+        } catch (IllegalArgumentException | IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        }
+    }
+
+    private boolean isYoutubeUrl(String url) {
+        try {
+            URI uri = URI.create(url.trim());
+            String host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            String normalized = host.toLowerCase(Locale.ROOT);
+            return normalized.equals("youtu.be")
+                    || normalized.endsWith(".youtube.com")
+                    || normalized.equals("youtube.com")
+                    || normalized.endsWith(".youtube-nocookie.com")
+                    || normalized.equals("youtube-nocookie.com");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private String youtubeSourceText(String url, String title, String author) {
+        StringBuilder builder = new StringBuilder();
+        appendLine(builder, "site", "YouTube");
+        appendLine(builder, "type", "video");
+        appendLine(builder, "url", url);
+        appendLine(builder, "title", title);
+        appendLine(builder, "channel", author);
+        return builder.toString().trim();
     }
 
     private boolean isHttpUrl(String url) {


### PR DESCRIPTION


<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- YouTube 링크는 oEmbed로 영상 제목 채널 썸네일 조회

- YouTube 요약 입력에 영상 메타데이터 전달

- 일반 OG 추출 실패 시 기존 HTML fallback 유지


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
