### PR TITLE
feat(memo): 다중 이미지 메모 생성 지원

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/api/dto/CreateBoardRequest.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/api/dto/CreateBoardRequest.java
@@ -2,6 +2,7 @@ package memme.memoryme.board.api.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "보드 생성 요청 DTO")
@@ -11,6 +12,8 @@ public record CreateBoardRequest(
         @Schema(description = "보드 설명", example = "동아리 관련 공지와 자료 모음")
         String description,
         @Schema(description = "태그 목록", example = "[\"동아리\", \"학교\"]")
-        List<String> tags
+        List<String> tags,
+        @Schema(description = "보드 생성 시각. 생략하면 서버 현재 시각이 사용됩니다.", example = "2026-05-30T20:30:00")
+        LocalDateTime createdAt
 ) {
 }

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -47,6 +47,8 @@ public class BoardServiceImpl implements BoardService {
                 .description(blankToNull(request.description()))
                 .tags(normalizeTags(request.tags()))
                 .bookmarked(false)
+                .createdAt(request.createdAt())
+                .updatedAt(request.createdAt())
                 .build();
 
         return BoardDto.from(boardRepository.saveAndFlush(board), this::resolveAttachmentUrl);

--- a/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/MemoController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/MemoController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,9 +27,9 @@ public class MemoController implements MemoApi {
     }
 
     @Override
-    public ResponseEntity<ResponseWrapper<MemoDto>> createImageMemo(String content, MultipartFile file) {
+    public ResponseEntity<ResponseWrapper<MemoDto>> createImageMemo(String content, List<MultipartFile> files, MultipartFile file) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
-                ResponseWrapper.ok(201, "이미지 메모 생성 성공", memoService.createImageMemo(content, file))
+                ResponseWrapper.ok(201, "이미지 메모 생성 성공", memoService.createImageMemo(content, resolvedFiles(files, file)))
         );
     }
 
@@ -73,5 +74,12 @@ public class MemoController implements MemoApi {
         return ResponseEntity.ok(
                 ResponseWrapper.ok(200, "메모를 기존 보드에 추가 성공", memoService.convertToExistingBoard(memoUid, boardUid, request))
         );
+    }
+
+    private List<MultipartFile> resolvedFiles(List<MultipartFile> files, MultipartFile file) {
+        if (files != null && !files.isEmpty()) {
+            return files;
+        }
+        return file == null ? List.of() : List.of(file);
     }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/api/MemoApi.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/api/controller/api/MemoApi.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Memo API", description = "빠른 메모 API")
@@ -40,11 +41,12 @@ public interface MemoApi {
             @RequestBody NewMemoDto request
     );
 
-    @Operation(summary = "이미지 메모 생성", description = "이미지 파일 하나를 업로드하고 첨부 메모를 한 번에 생성합니다.")
+    @Operation(summary = "이미지 메모 생성", description = "이미지 파일을 업로드하고 첨부 메모를 한 번에 생성합니다. 같은 요청의 여러 이미지는 하나의 메모에 함께 묶입니다.")
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<ResponseWrapper<MemoDto>> createImageMemo(
             @RequestPart(value = "content", required = false) String content,
-            @RequestPart("file") MultipartFile file
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            @RequestPart(value = "file", required = false) MultipartFile file
     );
 
     @Operation(summary = "영상 메모 생성", description = "영상 파일 하나를 업로드하고 첨부 메모를 한 번에 생성합니다.")

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/MemoService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/MemoService.java
@@ -4,11 +4,13 @@ import memme.memoryme.board.api.dto.BoardDto;
 import memme.memoryme.memo.api.dto.memo.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemoService {
     MemoDto createMemo(NewMemoDto request);
     MemoDto createImageMemo(String content, MultipartFile file);
+    MemoDto createImageMemo(String content, List<MultipartFile> files);
     MemoDto createVideoMemo(String content, MultipartFile file);
     MemoDto createFileMemo(String content, MultipartFile file);
     void deleteMemo(UUID memoUid);

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
@@ -69,7 +69,13 @@ public class MemoServiceImpl implements MemoService {
     @Override
     @Transactional
     public MemoDto createImageMemo(String content, MultipartFile file) {
-        ImageUploadResponse uploadResponse = uploadService.uploadImages(List.of(file));
+        return createImageMemo(content, List.of(file));
+    }
+
+    @Override
+    @Transactional
+    public MemoDto createImageMemo(String content, List<MultipartFile> files) {
+        ImageUploadResponse uploadResponse = uploadService.uploadImages(files);
         List<String> keys = uploadResponse.keys();
         try {
             return createMemo(new NewMemoDto(


### PR DESCRIPTION


<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- 보드 생성 요청에 createdAt 선택 입력 추가

- 이미지 메모 직접 생성 시 여러 이미지 일괄 업로드 지원

- 기존 단일 file 파트 호환 유지


### 🐞 관련 이슈
- Closes: #이슈번호 
- Related to: #이슈번호


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
