### PR TITLE
feat(withdrawal): 회원 탈퇴 시 유저 데이터 삭제 로직 구현

### DIFF
--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardService.java
@@ -19,4 +19,5 @@ public interface BoardService {
     void deleteNote(UUID boardUid, UUID noteUid);
     MoveNoteResponse moveNotes(UUID sourceBoardUid, MoveNoteRequest request);
     MoveNoteResponse moveNote(UUID sourceBoardUid, UUID noteUid, MoveNoteRequest request);
+    void deleteAllByUserUid(UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/board/application/service/BoardServiceImpl.java
@@ -86,6 +86,13 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
+    public void deleteAllByUserUid(UUID userUid) {
+        List<Board> boards = boardRepository.findAllByUserUid(userUid);
+        boardRepository.deleteAll(boards);
+    }
+
+    @Override
+    @Transactional
     public void deleteBoard(UUID boardUid) {
         UUID userUid = currentUserProvider.getUid();
         Board board = boardRepository.findByUidAndUserUid(boardUid, userUid)

--- a/MemoryMe/src/main/java/memme/memoryme/global/config/AppConfig.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/config/AppConfig.java
@@ -2,9 +2,13 @@ package memme.memoryme.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@EnableScheduling
+@EnableAsync
 public class AppConfig {
     @Bean
     public RestTemplate generalRestTemplate() {

--- a/MemoryMe/src/main/java/memme/memoryme/global/config/SecurityConfig.java
+++ b/MemoryMe/src/main/java/memme/memoryme/global/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                                 "/v1/auth/register",
                                 "/v1/email/**",
                                 "/uploads/**",
-                                "/v1/auth/kakao"
+                                "/v1/auth/kakao",
+                                "/v1/auth/pw/reset"
                         ).permitAll()
 
                         .anyRequest().authenticated()

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/MemoService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/MemoService.java
@@ -14,6 +14,7 @@ public interface MemoService {
     MemoDto createVideoMemo(String content, MultipartFile file);
     MemoDto createFileMemo(String content, MultipartFile file);
     void deleteMemo(UUID memoUid);
+    void deleteAllByUserUid(UUID userUid);
     MemoDto updateBookmark(UUID memoUid, BookmarkRequest request);
     BoardDto convertToNewBoard(UUID memoUid, ConvertMemoToNewBoardRequest request);
     BoardDto convertToExistingBoard(UUID memoUid, UUID boardUid, ConvertMemoToExistingBoardRequest request);

--- a/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/memo/application/service/impl/MemoServiceImpl.java
@@ -151,6 +151,13 @@ public class MemoServiceImpl implements MemoService {
 
     @Override
     @Transactional
+    public void deleteAllByUserUid(UUID userUid) {
+        List<Memo> memos = memoRepository.findAllByUserUid(userUid);
+        memoRepository.deleteAll(memos);
+    }
+
+    @Override
+    @Transactional
     public MemoDto updateBookmark(UUID memoUid, BookmarkRequest request) {
         UUID userUid = currentUserProvider.getUid();
         Memo memo = memoRepository.findByUidAndUserUid(memoUid, userUid)

--- a/MemoryMe/src/main/java/memme/memoryme/note/infra/repository/NoteAttachmentRepository.java
+++ b/MemoryMe/src/main/java/memme/memoryme/note/infra/repository/NoteAttachmentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -40,4 +41,7 @@ public interface NoteAttachmentRepository extends JpaRepository<NoteAttachment, 
             @Param("status") AttachmentStatus status,
             Pageable pageable
     );
+
+    @Query("select a.s3Key from NoteAttachment a where a.userUid = :userUid and a.s3Key is not null")
+    List<String> findAllS3KeysByUserUid(@Param("userUid") UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/pendinglink/application/service/PendingLinkService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/pendinglink/application/service/PendingLinkService.java
@@ -10,4 +10,5 @@ public interface PendingLinkService {
     CreatePendingLinkResponse create(CreatePendingLinkRequest request);
     PendingLinkListResponse getPendingLinks();
     void delete(UUID pendingLinkUid);
+    void deleteAllByUserUid(UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/pendinglink/application/service/PendingLinkServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/pendinglink/application/service/PendingLinkServiceImpl.java
@@ -68,6 +68,12 @@ public class PendingLinkServiceImpl implements PendingLinkService {
         pendingLinkRepository.deleteByUidAndUserUid(pendingLinkUid, userUid);
     }
 
+    @Override
+    @Transactional
+    public void deleteAllByUserUid(UUID userUid) {
+        pendingLinkRepository.deleteAllByUserUid(userUid);
+    }
+
     private void validateUrl(String url) {
         if (url == null || url.isBlank() || url.length() > 2048) {
             throw new BusinessException(PendingLinkErrorCode.INVALID_PENDING_LINK_REQUEST);

--- a/MemoryMe/src/main/java/memme/memoryme/pendinglink/infra/repository/PendingLinkRepository.java
+++ b/MemoryMe/src/main/java/memme/memoryme/pendinglink/infra/repository/PendingLinkRepository.java
@@ -15,4 +15,5 @@ public interface PendingLinkRepository extends JpaRepository<PendingLink, Long> 
     boolean existsByUidAndUserUid(UUID uid, UUID userUid);
     void deleteByUidAndUserUid(UUID uid, UUID userUid);
     long countByUserUid(UUID userUid);
+    void deleteAllByUserUid(UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/search/application/service/ElasticsearchSearchIndexService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/search/application/service/ElasticsearchSearchIndexService.java
@@ -34,6 +34,15 @@ public class ElasticsearchSearchIndexService implements SearchIndexService {
         }
     }
 
+    @Override
+    public void deleteUserIndex(UUID userUid) {
+        try {
+            deleteUserDocuments(userUid);
+        } catch (ElasticsearchException | IOException e) {
+            throw new BusinessException(SearchErrorCode.SEARCH_INDEX_FAILED);
+        }
+    }
+
     private void deleteUserDocuments(UUID userUid) throws IOException {
         elasticsearchClient.deleteByQuery(request -> request
                 .index(searchProperties.getIndexName())

--- a/MemoryMe/src/main/java/memme/memoryme/search/application/service/NoopSearchIndexService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/search/application/service/NoopSearchIndexService.java
@@ -16,4 +16,9 @@ public class NoopSearchIndexService implements SearchIndexService {
     public void reindexUser(UUID userUid, List<SearchDocument> documents) {
         throw new BusinessException(SearchErrorCode.SEARCH_DISABLED);
     }
+
+    @Override
+    public void deleteUserIndex(UUID userUid) {
+        // search disabled — no-op
+    }
 }

--- a/MemoryMe/src/main/java/memme/memoryme/search/application/service/SearchIndexService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/search/application/service/SearchIndexService.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface SearchIndexService {
     void reindexUser(UUID userUid, List<SearchDocument> documents);
+    void deleteUserIndex(UUID userUid);
 }

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/PendingS3DeleteService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/PendingS3DeleteService.java
@@ -1,0 +1,9 @@
+package memme.memoryme.upload.application.service;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PendingS3DeleteService {
+    void registerKeys(UUID userUid, List<String> s3Keys);
+    void processUserKeys(UUID userUid);
+}

--- a/MemoryMe/src/main/java/memme/memoryme/upload/application/service/PendingS3DeleteServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/application/service/PendingS3DeleteServiceImpl.java
@@ -1,0 +1,76 @@
+package memme.memoryme.upload.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import memme.memoryme.upload.domain.PendingS3Delete;
+import memme.memoryme.upload.infra.PendingS3DeleteRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PendingS3DeleteServiceImpl implements PendingS3DeleteService {
+
+    private final PendingS3DeleteRepository pendingS3DeleteRepository;
+    private final UploadService uploadService;
+
+    @Override
+    @Transactional
+    public void registerKeys(UUID userUid, List<String> s3Keys) {
+        if (s3Keys == null || s3Keys.isEmpty()) {
+            return;
+        }
+        List<PendingS3Delete> entries = s3Keys.stream()
+                .filter(key -> key != null && !key.isBlank())
+                .map(key -> PendingS3Delete.builder()
+                        .userUid(userUid)
+                        .s3Key(key.trim())
+                        .build())
+                .toList();
+        pendingS3DeleteRepository.saveAll(entries);
+    }
+
+    @Override
+    @Transactional
+    public void processUserKeys(UUID userUid) {
+        List<PendingS3Delete> pending = pendingS3DeleteRepository.findAllByUserUid(userUid);
+        deleteS3Keys(pending);
+    }
+
+    @Scheduled(fixedDelay = 3_600_000)
+    @Transactional
+    public void retryStale() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(1);
+        List<PendingS3Delete> stale = pendingS3DeleteRepository.findAllByCreatedAtBefore(threshold);
+        if (!stale.isEmpty()) {
+            log.info("Retrying {} stale pending S3 deletes", stale.size());
+            deleteS3Keys(stale);
+        }
+    }
+
+    private void deleteS3Keys(List<PendingS3Delete> entries) {
+        List<Long> successIds = entries.stream()
+                .filter(entry -> tryDeleteS3(entry.getS3Key()))
+                .map(PendingS3Delete::getId)
+                .toList();
+        if (!successIds.isEmpty()) {
+            pendingS3DeleteRepository.deleteAllById(successIds);
+        }
+    }
+
+    private boolean tryDeleteS3(String key) {
+        try {
+            uploadService.deleteObject(key);
+            return true;
+        } catch (Exception e) {
+            log.warn("S3 delete failed for key={}, will retry later", key, e);
+            return false;
+        }
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/upload/domain/PendingS3Delete.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/domain/PendingS3Delete.java
@@ -1,0 +1,39 @@
+package memme.memoryme.upload.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "pending_s3_delete", indexes = {
+        @Index(name = "idx_pending_s3_delete_user_uid", columnList = "user_uid"),
+        @Index(name = "idx_pending_s3_delete_created_at", columnList = "created_at")
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PendingS3Delete {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_uid", nullable = false, updatable = false)
+    private UUID userUid;
+
+    @Column(name = "s3_key", nullable = false, length = 512, updatable = false)
+    private String s3Key;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/upload/infra/PendingS3DeleteRepository.java
+++ b/MemoryMe/src/main/java/memme/memoryme/upload/infra/PendingS3DeleteRepository.java
@@ -1,0 +1,16 @@
+package memme.memoryme.upload.infra;
+
+import memme.memoryme.upload.domain.PendingS3Delete;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface PendingS3DeleteRepository extends JpaRepository<PendingS3Delete, Long> {
+    List<PendingS3Delete> findAllByUserUid(UUID userUid);
+    List<PendingS3Delete> findAllByCreatedAtBefore(LocalDateTime threshold);
+    void deleteAllByUserUid(UUID userUid);
+}

--- a/MemoryMe/src/main/java/memme/memoryme/withdrawal/api/WithdrawalTestController.java
+++ b/MemoryMe/src/main/java/memme/memoryme/withdrawal/api/WithdrawalTestController.java
@@ -1,0 +1,44 @@
+package memme.memoryme.withdrawal.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import memme.memoryme.global.util.jwt.CurrentUserProvider;
+import memme.memoryme.global.util.response.ResponseWrapper;
+import memme.memoryme.withdrawal.application.service.UserDataDeletionService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "[TEST] Withdrawal API", description = "회원 탈퇴 데이터 삭제 테스트용 (dev 환경 전용)")
+@ApiResponses({
+        @ApiResponse(responseCode = "200", description = "삭제 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+})
+@RestController
+@RequestMapping("/v1/test/withdrawal")
+@RequiredArgsConstructor
+@Profile({"dev", "local"})
+public class WithdrawalTestController {
+
+    private final UserDataDeletionService userDataDeletionService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Operation(
+            summary = "[TEST] 현재 로그인 유저 데이터 전체 삭제",
+            description = """
+                    현재 JWT로 인증된 유저의 모든 데이터를 삭제합니다. (memo, board, pendinglink, ES 인덱스)
+                    S3 파일은 트랜잭션 커밋 후 비동기로 삭제되며, 실패 시 pending_s3_delete 테이블에 남아 스케줄러가 재시도합니다.
+                    **dev 환경 전용 — prod에서는 활성화되지 않습니다.**
+                    """
+    )
+    @DeleteMapping("/my-data")
+    public ResponseEntity<ResponseWrapper<Void>> deleteMyData() {
+        userDataDeletionService.deleteUserData(currentUserProvider.getUid());
+        return ResponseEntity.ok(ResponseWrapper.ok(200, "유저 데이터 삭제 성공 (S3는 비동기 처리)", null));
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletedEvent.java
+++ b/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletedEvent.java
@@ -1,0 +1,6 @@
+package memme.memoryme.withdrawal.application.service;
+
+import java.util.UUID;
+
+public record UserDataDeletedEvent(UUID userUid) {
+}

--- a/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletedEventListener.java
+++ b/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletedEventListener.java
@@ -1,0 +1,21 @@
+package memme.memoryme.withdrawal.application.service;
+
+import lombok.RequiredArgsConstructor;
+import memme.memoryme.upload.application.service.PendingS3DeleteService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+@RequiredArgsConstructor
+public class UserDataDeletedEventListener {
+
+    private final PendingS3DeleteService pendingS3DeleteService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserDataDeleted(UserDataDeletedEvent event) {
+        pendingS3DeleteService.processUserKeys(event.userUid());
+    }
+}

--- a/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletionService.java
+++ b/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletionService.java
@@ -1,0 +1,12 @@
+package memme.memoryme.withdrawal.application.service;
+
+import java.util.UUID;
+
+public interface UserDataDeletionService {
+    /**
+     * 회원 탈퇴 시 user 모듈에서 호출.
+     * S3 키 수집 → pending_s3_delete 등록 → DB 데이터 전체 삭제를 단일 트랜잭션으로 처리.
+     * 트랜잭션 커밋 후 S3 삭제가 비동기로 실행됨.
+     */
+    void deleteUserData(UUID userUid);
+}

--- a/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletionServiceImpl.java
+++ b/MemoryMe/src/main/java/memme/memoryme/withdrawal/application/service/UserDataDeletionServiceImpl.java
@@ -1,0 +1,43 @@
+package memme.memoryme.withdrawal.application.service;
+
+import lombok.RequiredArgsConstructor;
+import memme.memoryme.board.application.service.BoardService;
+import memme.memoryme.memo.application.service.MemoService;
+import memme.memoryme.note.infra.repository.NoteAttachmentRepository;
+import memme.memoryme.pendinglink.application.service.PendingLinkService;
+import memme.memoryme.search.application.service.SearchIndexService;
+import memme.memoryme.upload.application.service.PendingS3DeleteService;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserDataDeletionServiceImpl implements UserDataDeletionService {
+
+    private final PendingLinkService pendingLinkService;
+    private final MemoService memoService;
+    private final BoardService boardService;
+    private final SearchIndexService searchIndexService;
+    private final NoteAttachmentRepository noteAttachmentRepository;
+    private final PendingS3DeleteService pendingS3DeleteService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    @Transactional
+    public void deleteUserData(UUID userUid) {
+        // S3 키를 DB 삭제 전에 수집해서 pending_s3_delete에 등록 (같은 트랜잭션)
+        List<String> s3Keys = noteAttachmentRepository.findAllS3KeysByUserUid(userUid);
+        pendingS3DeleteService.registerKeys(userUid, s3Keys);
+
+        pendingLinkService.deleteAllByUserUid(userUid);
+        memoService.deleteAllByUserUid(userUid);
+        boardService.deleteAllByUserUid(userUid);
+        searchIndexService.deleteUserIndex(userUid);
+
+        eventPublisher.publishEvent(new UserDataDeletedEvent(userUid));
+    }
+}


### PR DESCRIPTION


<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- withdrawal 모듈에 UserDataDeletionService 추가 (user 모듈에서 호출)
- pendinglink, memo, board, ES 인덱스 일괄 삭제 메서드 추가
- S3 파일은 pending_s3_delete 보상 테이블에 키 등록 후 커밋 완료 시 비동기 삭제
- 삭제 실패한 S3 키는 스케줄러가 1시간 주기로 재시도
- dev 환경 전용 테스트 엔드포인트 추가 (DELETE /v1/test/withdrawal/my-data)


### 🛠 리뷰 & 실행 확인 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [ ] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
<!-- 리뷰어가 특히 봐줬으면 하는 부분이나 궁금한 점 작성
-->

### 📸 스크린샷 (필요 시 첨부)
<!-- 프론트만
-->
